### PR TITLE
fix: display projects that only in the certain round

### DIFF
--- a/packages/interface/src/server/api/routers/projects.ts
+++ b/packages/interface/src/server/api/routers/projects.ts
@@ -80,6 +80,7 @@ export const projectsRouter = createTRPCRouter({
       orderBy: [createOrderBy(input.orderBy, input.sortOrder)],
       where: {
         attester: { equals: config.admin },
+        AND: filters,
       },
     });
   }),


### PR DESCRIPTION
**Description**
Add the filter of roundId back during the `Application` phase.

**Related Issues**
close #246 