### PR TITLE
fix: remove page error if wrong network

### DIFF
--- a/packages/interface/src/contexts/Maci.tsx
+++ b/packages/interface/src/contexts/Maci.tsx
@@ -76,7 +76,7 @@ export const MaciProvider: React.FC<MaciProviderProps> = ({ children }: MaciProv
       setGatekeeperTrait(gatekeeperType);
     };
 
-    fetchGatekeeperType();
+    fetchGatekeeperType().catch(console.error);
   }, [signer]);
 
   // only fetch the attestations if the gatekeeper trait is EAS


### PR DESCRIPTION
**Description**
catch error instead of letting it display full page error on the website
Since we already has the `Wrong Network` displayed on the wallet button, do nothing on catching this error.

**Related Issues**
close #245 