### PR TITLE
fix: disallow decimal numbers in ballot submission

### DIFF
--- a/packages/interface/src/features/ballot/components/AllocationInput.tsx
+++ b/packages/interface/src/features/ballot/components/AllocationInput.tsx
@@ -30,6 +30,7 @@ export const AllocationInput = ({
         render={({ field }) => (
           <NumericFormat
             allowNegative={false}
+            decimalScale={0}
             aria-label="allocation-input"
             customInput={Input}
             error={props.error}

--- a/packages/interface/src/features/projects/components/VotingWidget.tsx
+++ b/packages/interface/src/features/projects/components/VotingWidget.tsx
@@ -73,6 +73,7 @@ export const VotingWidget = ({ projectId }: IVotingWidgetProps): JSX.Element => 
       <div className="flex items-center justify-center gap-5 rounded-xl border border-gray-200 p-5 dark:border-gray-800">
         <NumericFormat
           allowNegative={false}
+          decimalScale={0}
           aria-label="allocation-input"
           autoComplete="off"
           className="dark:bg-lightBlack w-auto dark:text-white"


### PR DESCRIPTION
* Disallow decimal numbers in ballot submission
* `decimalScale` is used to [set the allowed number of decimal places](https://s-yadav.github.io/react-number-format/docs/numeric_format#decimalscale-number). A value of zero only allows integers 