### PR TITLE
fix: update gatekeeper, ballot callbacks and fix images for ballots

### DIFF
--- a/packages/interface/src/contexts/Ballot.tsx
+++ b/packages/interface/src/contexts/Ballot.tsx
@@ -25,7 +25,7 @@ export const BallotProvider: React.FC<BallotProviderProps> = ({ children }: Ball
         const amount = !Number.isNaN(Number(x.amount)) ? Number(x.amount) : 0;
         return sum + (pollData && pollData.mode.toString() === "0" ? amount ** 2 : amount);
       }, 0),
-    [],
+    [pollData],
   );
 
   const ballotContains = useCallback((id: string) => ballot.votes.find((v) => v.projectId === id), [ballot]);

--- a/packages/interface/src/contexts/Maci.tsx
+++ b/packages/interface/src/contexts/Maci.tsx
@@ -147,6 +147,9 @@ export const MaciProvider: React.FC<MaciProviderProps> = ({ children }: MaciProv
         });
         setIsLoading(false);
         break;
+      case GatekeeperTrait.FreeForAll:
+        setIsLoading(false);
+        break;
       default:
         break;
     }
@@ -159,7 +162,7 @@ export const MaciProvider: React.FC<MaciProviderProps> = ({ children }: MaciProv
   // for instance with semaphore
   const isEligibleToVote = useMemo(
     () => gatekeeperTrait && (gatekeeperTrait === GatekeeperTrait.FreeForAll || Boolean(sgData)) && Boolean(address),
-    [sgData, address],
+    [sgData, address, gatekeeperTrait],
   );
 
   // on load get the key pair from local storage and set the signature message

--- a/packages/interface/src/features/ballot/components/ProjectAvatarWithName.tsx
+++ b/packages/interface/src/features/ballot/components/ProjectAvatarWithName.tsx
@@ -23,7 +23,7 @@ export const ProjectAvatarWithName = ({
 
   return (
     <Component className="flex flex-1 items-center gap-4" href={`/projects/${id}`} tabIndex={-1}>
-      <ProjectAvatar profileId={projects?.[0]?.recipient} rounded="full" size="sm" />
+      <ProjectAvatar rounded="full" size="sm" url={metadata.data?.bannerImageUrl} />
 
       <div>
         <div className="font-bold uppercase">{projects?.[0]?.name}</div>


### PR DESCRIPTION
- Fix an issue where users aren't marked as valid to sign up if using Free For All Gatekeeper.
- Fix an issue where application images are empty or the same if created with an empty or repeated recipient account.
- Fix an issue where QV votes are not calculated correctly during the ballot.