### PR TITLE
chore: do not blur projects which are not approved yet

### DIFF
--- a/packages/interface/src/features/projects/components/ProjectDetails.tsx
+++ b/packages/interface/src/features/projects/components/ProjectDetails.tsx
@@ -1,4 +1,3 @@
-import clsx from "clsx";
 import { type ReactNode } from "react";
 
 import { Heading } from "~/components/ui/Heading";
@@ -20,14 +19,12 @@ export interface IProjectDetailsProps {
   action?: ReactNode;
   projectId?: string;
   attestation?: Attestation;
-  disabled?: boolean;
 }
 
 const ProjectDetails = ({
   projectId = "",
   attestation = undefined,
   action = undefined,
-  disabled = false,
 }: IProjectDetailsProps): JSX.Element => {
   const metadata = useProjectMetadata(attestation?.metadataPtr);
 
@@ -37,7 +34,7 @@ const ProjectDetails = ({
   const appState = useAppState();
 
   return (
-    <div className={clsx("relative dark:text-white", disabled && "opacity-30")}>
+    <div className="relative dark:text-white">
       <div className="mb-7">
         <Navigation projectName={attestation?.name ?? "project name"} />
       </div>

--- a/packages/interface/src/pages/projects/[projectId]/Project.tsx
+++ b/packages/interface/src/pages/projects/[projectId]/Project.tsx
@@ -1,8 +1,6 @@
 import { type GetServerSideProps } from "next";
-import { useMemo } from "react";
 
 import { ReviewBar } from "~/features/applications/components/ReviewBar";
-import { useApprovedApplications } from "~/features/applications/hooks/useApprovedApplications";
 import ProjectDetails from "~/features/projects/components/ProjectDetails";
 import { useProjectById } from "~/features/projects/hooks/useProjects";
 import { LayoutWithSidebar } from "~/layouts/DefaultLayout";
@@ -15,22 +13,14 @@ export interface IProjectDetailsProps {
 
 const ProjectDetailsPage = ({ projectId = "" }: IProjectDetailsProps): JSX.Element => {
   const projects = useProjectById(projectId);
-  const approved = useApprovedApplications();
   const { name } = projects.data?.[0] ?? {};
   const appState = useAppState();
-
-  const approvedById = useMemo(
-    () => new Map(approved.data?.map(({ refUID }) => [refUID, true]) ?? []),
-    [approved.data],
-  );
-
-  const disabled = useMemo(() => approvedById.get(projectId), [approvedById, projectId]);
 
   return (
     <LayoutWithSidebar eligibilityCheck showBallot showInfo sidebar="left" title={name}>
       {appState === EAppState.APPLICATION && <ReviewBar projectId={projectId} />}
 
-      <ProjectDetails attestation={projects.data?.[0]} disabled={!disabled} projectId={projectId} />
+      <ProjectDetails attestation={projects.data?.[0]} projectId={projectId} />
     </LayoutWithSidebar>
   );
 };


### PR DESCRIPTION
Blurring a non yet accepted application makes it very hard to review it. As it looks like non approved projects do not show up in the main projects page, and also during the application phase they are clearly labelled as not yet approved, maybe this blurring is not needed? @kittybest lmk your thoughts here or if I'm missing something