### PR TITLE
chore: use strings for metadata on contracts

### DIFF
--- a/packages/contracts/contracts/interfaces/IRecipientRegistry.sol
+++ b/packages/contracts/contracts/interfaces/IRecipientRegistry.sol
@@ -9,22 +9,22 @@ interface IRecipientRegistry {
     // recipient id (optional)
     bytes32 id;
     // recipient metadata url
-    bytes32 metadataUrl;
+    string metadataUrl;
     // recipient address
     address recipient;
   }
 
   /// @notice Events
-  event RecipientAdded(uint256 indexed index, bytes32 id, bytes32 indexed metadataUrl, address indexed payout);
+  event RecipientAdded(uint256 indexed index, bytes32 id, string metadataUrl, address indexed payout);
   event RecipientRemoved(uint256 indexed index, bytes32 id, address indexed payout);
-  event RecipientChanged(uint256 indexed index, bytes32 id, bytes32 indexed metadataUrl, address indexed newPayout);
+  event RecipientChanged(uint256 indexed index, bytes32 id, string metadataUrl, address indexed newPayout);
 
   /// @notice Custom errors
   error MaxRecipientsReached();
 
   /// @notice Get a registry metadata url
-  /// @return The metadata url in bytes32 format
-  function getRegistryMetadataUrl() external view returns (bytes32);
+  /// @return The metadata url in a string format
+  function getRegistryMetadataUrl() external view returns (string memory);
 
   /// @notice Add a recipient
   /// @param recipient The recipient data

--- a/packages/contracts/contracts/interfaces/IRegistryManager.sol
+++ b/packages/contracts/contracts/interfaces/IRegistryManager.sol
@@ -41,7 +41,7 @@ interface IRegistryManager {
     bytes32 indexed recipient,
     uint256 index,
     address payout,
-    bytes32 metadataUrl
+    string metadataUrl
   );
   event RequestApproved(
     address indexed registry,
@@ -49,7 +49,7 @@ interface IRegistryManager {
     bytes32 indexed recipient,
     uint256 index,
     address payout,
-    bytes32 metadataUrl
+    string metadataUrl
   );
   event RequestRejected(
     address indexed registry,
@@ -57,7 +57,7 @@ interface IRegistryManager {
     bytes32 indexed recipient,
     uint256 index,
     address payout,
-    bytes32 metadataUrl
+    string metadataUrl
   );
 
   /// @notice Custom errors

--- a/packages/contracts/contracts/mocks/MockRegistry.sol
+++ b/packages/contracts/contracts/mocks/MockRegistry.sol
@@ -10,5 +10,5 @@ contract MockRegistry is BaseRegistry {
   /// @param max The maximum number of projects that can be registered
   /// @param url The metadata url
   /// @param ownerAddress The owner address
-  constructor(uint256 max, bytes32 url, address ownerAddress) payable BaseRegistry(max, url, ownerAddress) {}
+  constructor(uint256 max, string memory url, address ownerAddress) payable BaseRegistry(max, url, ownerAddress) {}
 }

--- a/packages/contracts/contracts/registry/BaseRegistry.sol
+++ b/packages/contracts/contracts/registry/BaseRegistry.sol
@@ -19,19 +19,19 @@ abstract contract BaseRegistry is Ownable, IRecipientRegistry, ICommon {
   uint256 public recipientCount;
 
   /// @notice The registry metadata url
-  bytes32 public immutable metadataUrl;
+  string internal metadataUrl;
 
   /// @notice Create a new instance of the registry contract
   /// @param max The maximum number of recipients that can be registered
   /// @param url The metadata url
   /// @param ownerAddress The owner address
-  constructor(uint256 max, bytes32 url, address ownerAddress) payable Ownable(ownerAddress) {
+  constructor(uint256 max, string memory url, address ownerAddress) payable Ownable(ownerAddress) {
     maxRecipients = max;
     metadataUrl = url;
   }
 
   /// @inheritdoc IRecipientRegistry
-  function getRegistryMetadataUrl() public view virtual override returns (bytes32) {
+  function getRegistryMetadataUrl() public view virtual override returns (string memory) {
     return metadataUrl;
   }
 

--- a/packages/contracts/contracts/registry/EASRegistry.sol
+++ b/packages/contracts/contracts/registry/EASRegistry.sol
@@ -17,7 +17,7 @@ contract EASRegistry is BaseRegistry, IEAS {
   /// @param ownerAddress The owner address
   constructor(
     uint256 max,
-    bytes32 url,
+    string memory url,
     address easAddress,
     address ownerAddress
   ) payable BaseRegistry(max, url, ownerAddress) {
@@ -29,12 +29,12 @@ contract EASRegistry is BaseRegistry, IEAS {
   }
 
   /// @notice Add multiple recipients to the registry
-  /// @param recipients The recipients
-  function addRecipients(Recipient[] calldata recipients) external onlyOwner {
-    uint256 length = recipients.length;
+  /// @param _recipients The recipients
+  function addRecipients(Recipient[] calldata _recipients) external onlyOwner {
+    uint256 length = _recipients.length;
 
     for (uint256 i = 0; i < length; ) {
-      addRecipient(recipients[i]);
+      addRecipient(_recipients[i]);
 
       unchecked {
         i++;

--- a/packages/contracts/tasks/deploy/poll/01-poll.ts
+++ b/packages/contracts/tasks/deploy/poll/01-poll.ts
@@ -1,5 +1,4 @@
 /* eslint-disable no-console */
-import { encodeBytes32String } from "ethers";
 import { ContractStorage, Deployment, EMode } from "maci-contracts";
 import { PubKey } from "maci-domainobjs";
 
@@ -66,7 +65,7 @@ deployment.deployTask(EDeploySteps.Poll, "Deploy poll").then((task) =>
       "easAddress",
     );
 
-    const registryArgs = [maxRecipients, encodeBytes32String(metadataUrl), easAddress, registryManagerAddress];
+    const registryArgs = [maxRecipients, metadataUrl, easAddress, registryManagerAddress];
     const pollRegistry = await deployment.deployContract(
       { name: REGISTRY_TYPES[registryManagerType] },
       ...registryArgs,

--- a/packages/contracts/tests/EASRegistry.test.ts
+++ b/packages/contracts/tests/EASRegistry.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { encodeBytes32String, Signer, ZeroAddress } from "ethers";
+import { Signer, ZeroAddress } from "ethers";
 import { getSigners, deployContract } from "maci-contracts";
 
 import { EASRegistry, MockEAS, ICommon__factory as ICommonFactory } from "../typechain-types";
@@ -18,7 +18,7 @@ describe("EASRegistry", () => {
   const schema = "0xfdcfdad2dbe7489e0ce56b260348b7f14e8365a8a325aef9834818c00d46b31b";
   const attestation = "0x0000000000000000000000000000000000000000000000000000000000000000";
   const newAttestation = "0x0000000000000000000000000000000000000000000000000000000000000001";
-  const metadataUrl = encodeBytes32String("url");
+  const metadataUrl = "url";
 
   before(async () => {
     [owner, user] = await getSigners();

--- a/packages/subgraph/schemas/schema.v1.graphql
+++ b/packages/subgraph/schemas/schema.v1.graphql
@@ -57,7 +57,7 @@ type RegistryManager @entity {
 
 type Recipient @entity {
   id: Bytes!
-  metadataUrl: Bytes!
+  metadataUrl: String!
   payout: Bytes!
   index: BigInt!
   deleted: Boolean!

--- a/packages/subgraph/src/registry.ts
+++ b/packages/subgraph/src/registry.ts
@@ -24,7 +24,7 @@ export function handleChangeRecipient(event: RecipientChanged): void {
     return;
   }
 
-  recipient.metadataUrl = event.params.metadataUrl;
+  recipient.metadataUrl = event.params.metadataUrl.toString();
   recipient.index = event.params.index;
   recipient.initialized = true;
   recipient.deleted = false;

--- a/packages/subgraph/src/utils/entity.ts
+++ b/packages/subgraph/src/utils/entity.ts
@@ -78,7 +78,7 @@ export const createOrLoadRegistry = (id: Address): Registry => {
 
 export const createOrLoadRecipient = (
   id: Bytes,
-  metadataUrl: Bytes,
+  metadataUrl: string,
   index: GraphBN,
   payout: Address,
   registry: Address,

--- a/packages/subgraph/templates/subgraph.template.yaml
+++ b/packages/subgraph/templates/subgraph.template.yaml
@@ -51,11 +51,11 @@ dataSources:
         - name: BaseRegistry
           file: ./node_modules/maci-platform-contracts/build/artifacts/contracts/registry/BaseRegistry.sol/BaseRegistry.json
       eventHandlers:
-        - event: RequestSent(indexed address,indexed uint8,indexed bytes32,uint256,address,bytes32)
+        - event: RequestSent(indexed address,indexed uint8,indexed bytes32,uint256,address,string)
           handler: handleRequestSent
-        - event: RequestApproved(indexed address,indexed uint8,indexed bytes32,uint256,address,bytes32)
+        - event: RequestApproved(indexed address,indexed uint8,indexed bytes32,uint256,address,string)
           handler: handleRequestApproved
-        - event: RequestRejected(indexed address,indexed uint8,indexed bytes32,uint256,address,bytes32)
+        - event: RequestRejected(indexed address,indexed uint8,indexed bytes32,uint256,address,string)
           handler: handleRequestRejected
       file: ./src/registryManager.ts
 templates:
@@ -104,9 +104,9 @@ templates:
         - name: Registry
           file: ./node_modules/maci-platform-contracts/build/artifacts/contracts/registry/BaseRegistry.sol/BaseRegistry.json
       eventHandlers:
-        - event: RecipientAdded(indexed uint256,bytes32,indexed bytes32,indexed address)
+        - event: RecipientAdded(indexed uint256,bytes32,string,indexed address)
           handler: handleAddRecipient
-        - event: RecipientChanged(indexed uint256,bytes32,indexed bytes32,indexed address)
+        - event: RecipientChanged(indexed uint256,bytes32,string,indexed address)
           handler: handleChangeRecipient
         - event: RecipientRemoved(indexed uint256,bytes32,indexed address)
           handler: handleRemoveRecipient

--- a/packages/subgraph/tests/registry/registry.test.ts
+++ b/packages/subgraph/tests/registry/registry.test.ts
@@ -20,7 +20,7 @@ describe("Registry", () => {
       Bytes.fromUTF8("id"),
       BigInt.fromI32(0),
       DEFAULT_PAYOUT_ADDRESS,
-      Bytes.fromUTF8("url"),
+      "url",
     );
 
     handleAddRecipient(event);
@@ -32,7 +32,7 @@ describe("Registry", () => {
     assert.fieldEquals("Recipient", recipient.id.toHex(), "index", event.params.index.toString());
     assert.fieldEquals("Recipient", recipient.id.toHex(), "deleted", "false");
     assert.fieldEquals("Recipient", recipient.id.toHex(), "initialized", "true");
-    assert.fieldEquals("Recipient", recipient.id.toHex(), "metadataUrl", event.params.metadataUrl.toHex());
+    assert.fieldEquals("Recipient", recipient.id.toHex(), "metadataUrl", event.params.metadataUrl);
     assert.fieldEquals("Recipient", recipient.id.toHex(), "payout", event.params.payout.toHex());
     assert.fieldEquals("Recipient", recipient.id.toHex(), "registry", DEFAULT_REGISTRY_ADDRESS.toHex());
   });
@@ -44,7 +44,7 @@ describe("Registry", () => {
         Bytes.fromUTF8("id"),
         BigInt.fromI32(0),
         DEFAULT_PAYOUT_ADDRESS,
-        Bytes.fromUTF8("url"),
+        "url",
       ),
     );
 
@@ -53,7 +53,7 @@ describe("Registry", () => {
       Bytes.fromUTF8("id"),
       BigInt.fromI32(0),
       DEFAULT_REGISTRY_ADDRESS,
-      Bytes.fromUTF8("url"),
+      "url",
     );
 
     handleChangeRecipient(event);
@@ -65,7 +65,7 @@ describe("Registry", () => {
     assert.fieldEquals("Recipient", recipient.id.toHex(), "index", event.params.index.toString());
     assert.fieldEquals("Recipient", recipient.id.toHex(), "deleted", "false");
     assert.fieldEquals("Recipient", recipient.id.toHex(), "initialized", "true");
-    assert.fieldEquals("Recipient", recipient.id.toHex(), "metadataUrl", event.params.metadataUrl.toHex());
+    assert.fieldEquals("Recipient", recipient.id.toHex(), "metadataUrl", event.params.metadataUrl);
     assert.fieldEquals("Recipient", recipient.id.toHex(), "payout", event.params.newPayout.toHex());
     assert.fieldEquals("Recipient", recipient.id.toHex(), "registry", DEFAULT_REGISTRY_ADDRESS.toHex());
   });
@@ -77,7 +77,7 @@ describe("Registry", () => {
         Bytes.fromUTF8("id"),
         BigInt.fromI32(0),
         DEFAULT_PAYOUT_ADDRESS,
-        Bytes.fromUTF8("url"),
+        "url",
       ),
     );
 

--- a/packages/subgraph/tests/registry/utils.ts
+++ b/packages/subgraph/tests/registry/utils.ts
@@ -9,13 +9,13 @@ export function createRecipientAddEvent(
   recipient: Bytes,
   index: GraphBN,
   payout: Address,
-  metadataUrl: Bytes,
+  metadataUrl: string,
 ): RecipientAdded {
   const event = newMockEvent();
 
   event.parameters.push(new ethereum.EventParam("index", ethereum.Value.fromUnsignedBigInt(index)));
   event.parameters.push(new ethereum.EventParam("id", ethereum.Value.fromBytes(recipient)));
-  event.parameters.push(new ethereum.EventParam("metadataUrl", ethereum.Value.fromBytes(metadataUrl)));
+  event.parameters.push(new ethereum.EventParam("metadataUrl", ethereum.Value.fromString(metadataUrl)));
   event.parameters.push(new ethereum.EventParam("payout", ethereum.Value.fromAddress(payout)));
 
   event.address = address;
@@ -28,13 +28,13 @@ export function createRecipientChangeEvent(
   recipient: Bytes,
   index: GraphBN,
   newPayout: Address,
-  metadataUrl: Bytes,
+  metadataUrl: string,
 ): RecipientChanged {
   const event = newMockEvent();
 
   event.parameters.push(new ethereum.EventParam("index", ethereum.Value.fromUnsignedBigInt(index)));
   event.parameters.push(new ethereum.EventParam("id", ethereum.Value.fromBytes(recipient)));
-  event.parameters.push(new ethereum.EventParam("metadataUrl", ethereum.Value.fromBytes(metadataUrl)));
+  event.parameters.push(new ethereum.EventParam("metadataUrl", ethereum.Value.fromString(metadataUrl)));
   event.parameters.push(new ethereum.EventParam("newPayout", ethereum.Value.fromAddress(newPayout)));
 
   event.address = address;

--- a/packages/subgraph/tests/registryManager/registryManager.test.ts
+++ b/packages/subgraph/tests/registryManager/registryManager.test.ts
@@ -34,7 +34,7 @@ describe("RegistryManager", () => {
         Bytes.fromUTF8("id"),
         BigInt.fromI32(0),
         DEFAULT_PAYOUT_ADDRESS,
-        Bytes.fromUTF8("metadataUrl"),
+        "metadataUrl",
       );
 
       handleRequestSent(sentEvent);
@@ -57,7 +57,7 @@ describe("RegistryManager", () => {
         Bytes.fromUTF8("id"),
         BigInt.fromI32(0),
         DEFAULT_PAYOUT_ADDRESS,
-        Bytes.fromUTF8("metadataUrl"),
+        "metadataUrl",
       );
 
       handleRequestApproved(approveEvent);
@@ -81,7 +81,7 @@ describe("RegistryManager", () => {
         Bytes.fromUTF8("id"),
         BigInt.fromI32(0),
         DEFAULT_PAYOUT_ADDRESS,
-        Bytes.fromUTF8("metadataUrl"),
+        "metadataUrl",
       );
 
       handleRequestSent(sentEvent);
@@ -104,7 +104,7 @@ describe("RegistryManager", () => {
         Bytes.fromUTF8("id"),
         BigInt.fromI32(0),
         DEFAULT_PAYOUT_ADDRESS,
-        Bytes.fromUTF8("metadataUrl"),
+        "metadataUrl",
       );
 
       handleRequestRejected(rejectEvent);

--- a/packages/subgraph/tests/registryManager/utils.ts
+++ b/packages/subgraph/tests/registryManager/utils.ts
@@ -9,7 +9,7 @@ export function createRequestEvent<T>(
   recipient: Bytes,
   index: GraphBN,
   payout: Address,
-  metadataUrl: Bytes,
+  metadataUrl: string,
 ): T {
   const event = newMockEvent();
 
@@ -18,7 +18,7 @@ export function createRequestEvent<T>(
   event.parameters.push(new ethereum.EventParam("recipient", ethereum.Value.fromBytes(recipient)));
   event.parameters.push(new ethereum.EventParam("index", ethereum.Value.fromUnsignedBigInt(index)));
   event.parameters.push(new ethereum.EventParam("payout", ethereum.Value.fromAddress(payout)));
-  event.parameters.push(new ethereum.EventParam("metadataUrl", ethereum.Value.fromBytes(metadataUrl)));
+  event.parameters.push(new ethereum.EventParam("metadataUrl", ethereum.Value.fromString(metadataUrl)));
 
   event.address = address;
 


### PR DESCRIPTION
Use strings for metadata pointers (note that strings in events to be indexed will be converted to its hash thus bytes32, hence why indexed was removed)

fix shadowing of recipients in EASRegistry