### PR TITLE
chore: add simple registry and move some arguments to registry config

### DIFF
--- a/packages/contracts/contracts/registry/SimpleRegistry.sol
+++ b/packages/contracts/contracts/registry/SimpleRegistry.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import { BaseRegistry } from "./BaseRegistry.sol";
+
+contract SimpleRegistry is BaseRegistry {
+  /// @notice Create a new instance of the registry contract
+  /// @param max The maximum number of projects that can be registered
+  /// @param url The metadata url
+  /// @param ownerAddress The owner address
+  constructor(
+    uint256 max,
+    string memory url,
+    address ownerAddress
+  ) payable BaseRegistry(max, url, ownerAddress) {}
+}

--- a/packages/contracts/deploy-config-example.json
+++ b/packages/contracts/deploy-config-example.json
@@ -31,14 +31,23 @@
       "groupId": 0
     },
     "MACI": {
-      "stateTreeDepth": 10,
-      "gatekeeper": "EASGatekeeper",
-      "registryManager": "EASRegistryManager"
+      "stateTreeDepth": 14,
+      "gatekeeper": "FreeForAllGatekeeper",
+      "registryManager": "RegistryManager",
+      "registry": "SimpleRegistry"
     },
+    "RegistryManager": {},
     "EASRegistryManager": {
+      "easAddress": "0x4200000000000000000000000000000000000021"
+    },
+    "SimpleRegistry": {
+      "maxRecipients": 25,
+      "metadataUrl": "url"
+    },
+    "EASRegistry": {
       "maxRecipients": 25,
       "metadataUrl": "url",
-      "easAddress": "0xC2679fBD37d54388Ce493F1DB75320D236e1815e"
+      "easAddress": "0x4200000000000000000000000000000000000021"
     },
     "VkRegistry": {
       "stateTreeDepth": 10,
@@ -98,14 +107,23 @@
       "groupId": 0
     },
     "MACI": {
-      "stateTreeDepth": 10,
-      "gatekeeper": "ZupassGatekeeper",
-      "registryManager": "EASRegistryManager"
+      "stateTreeDepth": 14,
+      "gatekeeper": "FreeForAllGatekeeper",
+      "registryManager": "RegistryManager",
+      "registry": "SimpleRegistry"
     },
+    "RegistryManager": {},
     "EASRegistryManager": {
+      "easAddress": "0x4200000000000000000000000000000000000021"
+    },
+    "SimpleRegistry": {
+      "maxRecipients": 25,
+      "metadataUrl": "url"
+    },
+    "EASRegistry": {
       "maxRecipients": 25,
       "metadataUrl": "url",
-      "easAddress": "0xaEF4103A04090071165F78D45D83A0C0782c2B2a"
+      "easAddress": "0x4200000000000000000000000000000000000021"
     },
     "VkRegistry": {
       "stateTreeDepth": 10,
@@ -166,11 +184,20 @@
       "groupId": 0
     },
     "MACI": {
-      "stateTreeDepth": 6,
-      "gatekeeper": "EASGatekeeper",
-      "registryManager": "EASRegistryManager"
+      "stateTreeDepth": 14,
+      "gatekeeper": "FreeForAllGatekeeper",
+      "registryManager": "RegistryManager",
+      "registry": "SimpleRegistry"
     },
+    "RegistryManager": {},
     "EASRegistryManager": {
+      "easAddress": "0x4200000000000000000000000000000000000021"
+    },
+    "SimpleRegistry": {
+      "maxRecipients": 25,
+      "metadataUrl": "url"
+    },
+    "EASRegistry": {
       "maxRecipients": 25,
       "metadataUrl": "url",
       "easAddress": "0x4200000000000000000000000000000000000021"
@@ -234,14 +261,23 @@
       "groupId": 0
     },
     "MACI": {
-      "stateTreeDepth": 10,
+      "stateTreeDepth": 14,
       "gatekeeper": "FreeForAllGatekeeper",
-      "registryManager": "EASRegistryManager"
+      "registryManager": "RegistryManager",
+      "registry": "SimpleRegistry"
     },
+    "RegistryManager": {},
     "EASRegistryManager": {
+      "easAddress": "0x4200000000000000000000000000000000000021"
+    },
+    "SimpleRegistry": {
+      "maxRecipients": 25,
+      "metadataUrl": "url"
+    },
+    "EASRegistry": {
       "maxRecipients": 25,
       "metadataUrl": "url",
-      "easAddress": "0xC2679fBD37d54388Ce493F1DB75320D236e1815e"
+      "easAddress": "0x4200000000000000000000000000000000000021"
     },
     "VkRegistry": {
       "stateTreeDepth": 10,
@@ -302,14 +338,23 @@
       "groupId": 0
     },
     "MACI": {
-      "stateTreeDepth": 10,
+      "stateTreeDepth": 14,
       "gatekeeper": "FreeForAllGatekeeper",
-      "registryManager": "EASRegistryManager"
+      "registryManager": "RegistryManager",
+      "registry": "SimpleRegistry"
     },
+    "RegistryManager": {},
     "EASRegistryManager": {
+      "easAddress": "0x4200000000000000000000000000000000000021"
+    },
+    "SimpleRegistry": {
+      "maxRecipients": 25,
+      "metadataUrl": "url"
+    },
+    "EASRegistry": {
       "maxRecipients": 25,
       "metadataUrl": "url",
-      "easAddress": "0xC2679fBD37d54388Ce493F1DB75320D236e1815e"
+      "easAddress": "0x4200000000000000000000000000000000000021"
     },
     "VkRegistry": {
       "stateTreeDepth": 10,
@@ -370,11 +415,20 @@
       "groupId": 0
     },
     "MACI": {
-      "stateTreeDepth": 10,
+      "stateTreeDepth": 14,
       "gatekeeper": "FreeForAllGatekeeper",
-      "registryManager": "EASRegistryManager"
+      "registryManager": "RegistryManager",
+      "registry": "SimpleRegistry"
     },
+    "RegistryManager": {},
     "EASRegistryManager": {
+      "easAddress": "0x4200000000000000000000000000000000000021"
+    },
+    "SimpleRegistry": {
+      "maxRecipients": 25,
+      "metadataUrl": "url"
+    },
+    "EASRegistry": {
       "maxRecipients": 25,
       "metadataUrl": "url",
       "easAddress": "0x4200000000000000000000000000000000000021"
@@ -445,9 +499,18 @@
     "MACI": {
       "stateTreeDepth": 14,
       "gatekeeper": "FreeForAllGatekeeper",
-      "registryManager": "EASRegistryManager"
+      "registryManager": "RegistryManager",
+      "registry": "SimpleRegistry"
     },
+    "RegistryManager": {},
     "EASRegistryManager": {
+      "easAddress": "0x4200000000000000000000000000000000000021"
+    },
+    "SimpleRegistry": {
+      "maxRecipients": 25,
+      "metadataUrl": "url"
+    },
+    "EASRegistry": {
       "maxRecipients": 25,
       "metadataUrl": "url",
       "easAddress": "0x4200000000000000000000000000000000000021"

--- a/packages/contracts/tasks/deploy/poll/01-poll.ts
+++ b/packages/contracts/tasks/deploy/poll/01-poll.ts
@@ -3,7 +3,7 @@ import { ContractStorage, Deployment, EMode } from "maci-contracts";
 import { PubKey } from "maci-domainobjs";
 
 import { type Poll, type MACI } from "../../../typechain-types";
-import { EContracts, EDeploySteps, REGISTRY_TYPES, TRegistryManager } from "../../helpers/constants";
+import { EContracts, EDeploySteps, REGISTRY_TYPES, TRegistryManager, TRegistry } from "../../helpers/constants";
 
 const deployment = Deployment.getInstance();
 const storage = ContractStorage.getInstance();
@@ -52,20 +52,21 @@ deployment.deployTask(EDeploySteps.Poll, "Deploy poll").then((task) =>
       deployment.getDeployConfigField<TRegistryManager | null>(EContracts.MACI, "registryManager") ||
       EContracts.EASRegistryManager;
     const registryManagerAddress = storage.getAddress(registryManagerType, hre.network.name);
+
+    const registryType =
+      deployment.getDeployConfigField<TRegistry | null>(EContracts.MACI, "registry") || EContracts.EASRegistry;
+
     const maxRecipients = deployment.getDeployConfigField<number, keyof typeof EContracts>(
-      EContracts.EASRegistryManager,
+      registryType,
       "maxRecipients",
     );
-    const metadataUrl = deployment.getDeployConfigField<string, keyof typeof EContracts>(
-      EContracts.EASRegistryManager,
-      "metadataUrl",
-    );
-    const easAddress = deployment.getDeployConfigField<string, keyof typeof EContracts>(
-      EContracts.EASRegistryManager,
-      "easAddress",
-    );
+    const metadataUrl = deployment.getDeployConfigField<string, keyof typeof EContracts>(registryType, "metadataUrl");
+    const easAddress = deployment.getDeployConfigField<string, keyof typeof EContracts>(registryType, "easAddress");
 
-    const registryArgs = [maxRecipients, metadataUrl, easAddress, registryManagerAddress];
+    const registryArgs =
+      registryType === EContracts.EASRegistry
+        ? [maxRecipients, metadataUrl, easAddress, registryManagerAddress]
+        : [maxRecipients, metadataUrl, registryManagerAddress];
     const pollRegistry = await deployment.deployContract(
       { name: REGISTRY_TYPES[registryManagerType] },
       ...registryArgs,

--- a/packages/contracts/tasks/helpers/constants/index.ts
+++ b/packages/contracts/tasks/helpers/constants/index.ts
@@ -20,7 +20,9 @@ export const EDeploySteps = {
  */
 export enum EPlatformContracts {
   EASRegistryManager = "EASRegistryManager",
+  RegistryManager = "RegistryManager",
   EASRegistry = "EASRegistry",
+  SimpleRegistry = "SimpleRegistry",
 }
 
 /**
@@ -34,18 +36,19 @@ export const EContracts = {
 /**
  * Supported registry manager types
  */
-export type TRegistryManager = EPlatformContracts.EASRegistryManager;
+export type TRegistryManager = EPlatformContracts.EASRegistryManager | EPlatformContracts.RegistryManager;
 
 /**
  * Supported registry types
  */
-export type TRegistry = EPlatformContracts.EASRegistry;
+export type TRegistry = EPlatformContracts.EASRegistry | EPlatformContracts.SimpleRegistry;
 
 /**
  * Registry types by registry manager
  */
 export const REGISTRY_TYPES: Record<TRegistryManager, TRegistry> = {
   [EPlatformContracts.EASRegistryManager]: EPlatformContracts.EASRegistry,
+  [EPlatformContracts.RegistryManager]: EPlatformContracts.SimpleRegistry,
 };
 
 /**


### PR DESCRIPTION
**Description**
The arguments for Registry contracts are written in the RegistryManager config field, which looks weird. Move those out, and add `SimpleRegistry` contract base on this PR: #337 