### PR TITLE
docs: update 01_setup.md guide

### DIFF
--- a/docs/01_setup.md
+++ b/docs/01_setup.md
@@ -134,10 +134,10 @@ At the very minimum you need to configure a **subgraph**, **admin address**, **M
 
 ### Subgraph
 
-Got to the **MACI** repo and head to the subgraph folder.
+Go to the subgraph folder.
 
 ```bash
-cd apps/subgraph
+cd packages/subgraph
 ```
 
 1. Change the network name inside the `network.json` file in the `config` folder, using one of the CLI names supported for subgraph network [https://thegraph.com/docs/en/developing/supported-networks/](https://thegraph.com/docs/en/developing/supported-networks/).


### PR DESCRIPTION
## Description
Update `01_setup.md` guide from this repo, needed for a clear path to installing and running maci-platform with a running votin ground (poll).
## Fixes
- Updates steps for maci-platform version > 2
- Clarifies steps on env variables, repo navigation, warnings placement before commands, subgraph, and prioritize test over production.
- Removes high dependency from the video guide
## Pending
- Check step 5 of section '3. Configuration' (I could not understand this clearly)
-  Everything from section '4. Deploy Frontend' onwards (did not do this myself).
- An update to the video guide (I can also do this).