### PR TITLE
fix(form): show error at the end if inputs are not valid

### DIFF
--- a/packages/interface/src/components/ImageUpload.tsx
+++ b/packages/interface/src/components/ImageUpload.tsx
@@ -1,7 +1,7 @@
 import { useMutation } from "@tanstack/react-query";
 import clsx from "clsx";
 import { ImageIcon } from "lucide-react";
-import { type ComponentProps, useRef } from "react";
+import { type ComponentProps, useRef, useCallback } from "react";
 import { Controller, useFormContext } from "react-hook-form";
 import { toast } from "sonner";
 
@@ -33,6 +33,10 @@ export const ImageUpload = ({
     },
   });
 
+  const onClickIconButton = useCallback((e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+  }, []);
+
   return (
     <Controller
       control={control}
@@ -43,7 +47,7 @@ export const ImageUpload = ({
           className={clsx("relative cursor-pointer overflow-hidden", className)}
           onClick={() => ref.current?.click()}
         >
-          <IconButton className="absolute bottom-1 right-1" icon={ImageIcon} />
+          <IconButton className="absolute bottom-1 right-1" icon={ImageIcon} onClick={onClickIconButton} />
 
           <div
             className={clsx("h-full rounded-xl bg-gray-200 bg-cover bg-center bg-no-repeat")}

--- a/packages/interface/src/features/applications/components/ApplicationsToApprove.tsx
+++ b/packages/interface/src/features/applications/components/ApplicationsToApprove.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { useRouter } from "next/router";
 import { useEffect, useCallback, useMemo } from "react";
 import { FiAlertCircle } from "react-icons/fi";
 import { zeroAddress } from "viem";
@@ -26,6 +27,7 @@ interface IApplicationsToApproveProps {
  * Displays the applications that are pending approval.
  */
 export const ApplicationsToApprove = ({ pollId }: IApplicationsToApproveProps): JSX.Element => {
+  const router = useRouter();
   const { getRoundByPollId } = useRound();
 
   const round = useMemo(() => getRoundByPollId(pollId), [pollId, getRoundByPollId]);
@@ -73,7 +75,7 @@ export const ApplicationsToApprove = ({ pollId }: IApplicationsToApproveProps): 
 
           {!pending.isLoading && !pending.data?.length ? (
             <EmptyState title="No pending applications">
-              <Button as={Link} href={`/rounds/${pollId}/applications/new`} variant="primary">
+              <Button as={Link} href={`${router.asPath}/new`} variant="primary">
                 Go to create application
               </Button>
             </EmptyState>


### PR DESCRIPTION
**Problem**

The `Form` component uses pages for forms that have multiple sections. In each section the inputs already alert the user about some conditions (e.g.: you need a valid eth address, this field needs at least 3 words, etc). 

The problem happens in the end. If the user ignored the warnings of each input in each section, then the form is not valid and cannot be submitted. When the user press the submit button nothing happens (no alert).

**Solution**

Detect if the form has any validation errors and tell the user that when he presses the submit button. That way the user will know he needs to trace back and find the input validation error.


**Extras**

1. Delete "Applications" from top navbar
2. "Create New Application" button in each round sends to the `/rounds/[roundId]/new` page
