### PR TITLE
feat: update voting start and end time

### DIFF
--- a/packages/coordinator/scripts/uploadRoundMetadata.ts
+++ b/packages/coordinator/scripts/uploadRoundMetadata.ts
@@ -24,8 +24,7 @@ interface IUploadMetadataProps {
 dotenv.config({ path: path.resolve(import.meta.dirname, "../.env") });
 
 function isValidDate(formattedDateStr: string) {
-  const splitDate = formattedDateStr.split("-");
-  const parsed = parse(`${splitDate[2]}/${splitDate[1]}/${splitDate[0]}`, "P", new Date(), { locale: enGB });
+  const parsed = parse(`${formattedDateStr}Z`, "yyyy/M/d H:m:sX", new Date(), { locale: enGB });
   return isValid(parsed);
 }
 
@@ -66,23 +65,26 @@ export async function collectMetadata(): Promise<RoundMetadata> {
 
   const askStartTime = () =>
     new Promise<Date>((resolve, reject) => {
-      rl.question("When would you like to start this round? (Please respond in the format yyyy-mm-dd) ", (answer) => {
-        const valid = isValidDate(answer);
+      rl.question(
+        "When would you like to start this round? (Please respond in the format {Year}/{Month}/{Day} {Hour}:{Minute}:{Second} in UTC time) ",
+        (answer) => {
+          const valid = isValidDate(answer);
 
-        if (!valid) {
-          reject(new Error("Please answer in valid format."));
-        }
+          if (!valid) {
+            reject(new Error("Please answer in valid format."));
+          }
 
-        // eslint-disable-next-line no-console
-        console.log("You would like to start this round at:", answer);
-        resolve(new Date(answer));
-      });
+          // eslint-disable-next-line no-console
+          console.log("You would like to start this round at:", answer);
+          resolve(new Date(answer));
+        },
+      );
     });
 
   const askRegistrationEndTime = () =>
     new Promise<Date>((resolve, reject) => {
       rl.question(
-        "When would you like to end the registration for applications? (Please respond in the format yyyy-mm-dd) ",
+        "When would you like to end the registration for applications? (Please respond in the format {Year}/{Month}/{Day} {Hour}:{Minute}:{Second} in UTC time) ",
         (answer) => {
           const valid = isValidDate(answer);
 
@@ -100,7 +102,7 @@ export async function collectMetadata(): Promise<RoundMetadata> {
   const askVotingStartTime = () =>
     new Promise<Date>((resolve, reject) => {
       rl.question(
-        "When would you like to start the voting for this round? (Please respond in the format yyyy-mm-dd) ",
+        "When would you like to start the voting for this round? (Please respond in the format {Year}/{Month}/{Day} {Hour}:{Minute}:{Second} in UTC time) ",
         (answer) => {
           const valid = isValidDate(answer);
 
@@ -118,7 +120,7 @@ export async function collectMetadata(): Promise<RoundMetadata> {
   const askVotingEndTime = () =>
     new Promise<Date>((resolve, reject) => {
       rl.question(
-        "When would you like to end the voting for this round? (Please respond in the format yyyy-mm-dd) ",
+        "When would you like to end the voting for this round? (Please respond in the format {Year}/{Month}/{Day} {Hour}:{Minute}:{Second} in UTC time) ",
         (answer) => {
           const valid = isValidDate(answer);
 

--- a/packages/interface/src/server/api/routers/maci.ts
+++ b/packages/interface/src/server/api/routers/maci.ts
@@ -16,6 +16,7 @@ const PollSchema = z.object({
   duration: z.union([z.string(), z.number(), z.bigint()]),
   deployTime: z.union([z.string(), z.number(), z.bigint()]),
   numSignups: z.union([z.string(), z.number(), z.bigint()]),
+  initTime: z.union([z.string(), z.number(), z.bigint()]).nullable(),
   registryAddress: z.string(),
   metadataUrl: z.string(),
 }) satisfies ZodType<IPollData>;
@@ -31,21 +32,26 @@ export const maciRouter = createTRPCRouter({
         fetchMetadata<IRoundMetadata>(poll.metadataUrl).then((metadata) => {
           const data = metadata as unknown as IRoundMetadata;
 
+          const votingStartsAt =
+            poll.initTime === null ? new Date(data.votingStartsAt) : new Date(Number(poll.initTime) * 1000);
+          const votingEndsAt =
+            poll.initTime === null
+              ? new Date(data.votingEndsAt)
+              : new Date((Number(poll.initTime) + Number(poll.duration)) * 1000);
+
           return {
             isMerged: poll.isMerged,
             pollId: poll.id,
-            duration: poll.duration,
-            deployTime: poll.deployTime,
             numSignups: poll.numSignups,
             pollAddress: poll.address,
             mode: poll.mode,
             registryAddress: poll.registryAddress,
             roundId: data.roundId,
             description: data.description,
-            startsAt: data.startsAt,
-            registrationEndsAt: data.registrationEndsAt,
-            votingStartsAt: data.votingStartsAt,
-            votingEndsAt: data.votingEndsAt,
+            startsAt: new Date(data.startsAt),
+            registrationEndsAt: new Date(data.registrationEndsAt),
+            votingStartsAt,
+            votingEndsAt,
             tallyFile: data.tallyFile,
           } as IRoundData;
         }),

--- a/packages/interface/src/utils/state.ts
+++ b/packages/interface/src/utils/state.ts
@@ -13,15 +13,15 @@ export const useRoundState = (roundId: string): ERoundState => {
     return ERoundState.DEFAULT;
   }
 
-  if (round.registrationEndsAt && isAfter(round.registrationEndsAt, now)) {
+  if (isAfter(round.registrationEndsAt, now)) {
     return ERoundState.APPLICATION;
   }
 
-  if (round.votingEndsAt && isAfter(round.votingEndsAt, now)) {
+  if (isAfter(round.votingEndsAt, now)) {
     return ERoundState.VOTING;
   }
 
-  if (round.votingEndsAt && isAfter(now, round.votingEndsAt)) {
+  if (isAfter(now, round.votingEndsAt)) {
     return ERoundState.TALLYING;
   }
 

--- a/packages/interface/src/utils/types.ts
+++ b/packages/interface/src/utils/types.ts
@@ -94,6 +94,7 @@ export const AttestationsQuery = `
 export interface IPollData extends IGetPollData {
   registryAddress: string;
   metadataUrl: string;
+  initTime: bigint | number | string | null;
 }
 
 export interface IRoundMetadata {
@@ -109,17 +110,15 @@ export interface IRoundMetadata {
 export interface IRoundData {
   isMerged: boolean;
   pollId: string;
-  duration: string;
-  deployTime: string;
   numSignups: string;
   pollAddress: string;
   mode: string;
   registryAddress: string;
   roundId: string;
   description: string;
-  startsAt: string;
-  registrationEndsAt: string;
-  votingStartsAt: string;
-  votingEndsAt: string;
+  startsAt: Date;
+  registrationEndsAt: Date;
+  votingStartsAt: Date;
+  votingEndsAt: Date;
   tallyFile: string;
 }


### PR DESCRIPTION
**Description**
If the poll is deployed but not inited, the `initTime` would be `null`, so to display this round data, we would rely on the metadata file. However, once the poll is inited, the `initTime` would be the inited date, then we should change both the `votingStartsAt` and `votingEndsAt` to match the `initTime` and `initTime + duration`.

- [x] update the above description
- [x] update how metadata upload script get the date information (should include the timezone)