### PR TITLE
feat(tally-fetch): Added fetch from subgraph

### DIFF
--- a/packages/interface/src/server/api/routers/maci.ts
+++ b/packages/interface/src/server/api/routers/maci.ts
@@ -4,6 +4,7 @@ import { z, ZodType } from "zod";
 import { createTRPCRouter, publicProcedure } from "~/server/api/trpc";
 import { fetchMetadata } from "~/utils/fetchMetadata";
 import { fetchPolls } from "~/utils/fetchPoll";
+import { fetchTally } from "~/utils/fetchTally";
 import { fetchUser } from "~/utils/fetchUser";
 
 import type { IPollData, IRoundMetadata, IRoundData } from "~/utils/types";
@@ -26,6 +27,7 @@ export const maciRouter = createTRPCRouter({
     .input(z.object({ publicKey: z.string() }))
     .query(async ({ input }) => fetchUser(PubKey.deserialize(input.publicKey).rawPubKey)),
   poll: publicProcedure.query(async () => fetchPolls()),
+  tally: publicProcedure.input(z.object({ id: z.string() })).query(async ({ input }) => fetchTally(input.id)),
   round: publicProcedure.input(z.object({ polls: z.array(PollSchema) })).query(async ({ input }) =>
     Promise.all(
       input.polls.map((poll) =>
@@ -52,7 +54,6 @@ export const maciRouter = createTRPCRouter({
             registrationEndsAt: new Date(data.registrationEndsAt),
             votingStartsAt,
             votingEndsAt,
-            tallyFile: data.tallyFile,
           } as IRoundData;
         }),
       ),

--- a/packages/interface/src/utils/fetchTally.ts
+++ b/packages/interface/src/utils/fetchTally.ts
@@ -1,0 +1,39 @@
+import { config } from "~/config";
+
+import type { Tally } from "./types";
+
+import { createCachedFetch } from "./fetch";
+
+const cachedFetch = createCachedFetch({ ttl: 1000 * 60 * 10 });
+
+export interface GraphQLResponse {
+  data?: {
+    tally: Tally;
+  };
+}
+
+const tallyQuery = `
+  query Tally {
+    tally(id: $id) {
+      id
+      results {
+        id
+        result
+      }
+    }
+  }
+`;
+
+/**
+ * Fetches the tally data from the subgraph
+ *
+ * @returns The tally data
+ */
+export async function fetchTally(id: string): Promise<Tally | undefined> {
+  return cachedFetch<{ tally: Tally }>(config.maciSubgraphUrl, {
+    method: "POST",
+    body: JSON.stringify({
+      query: tallyQuery.replace("id: $id", `id: "${id}"`),
+    }),
+  }).then((response: GraphQLResponse) => response.data?.tally);
+}

--- a/packages/interface/src/utils/types.ts
+++ b/packages/interface/src/utils/types.ts
@@ -75,6 +75,11 @@ export interface Metadata {
   type: string;
 }
 
+export interface TallyResult {
+  id: string;
+  result: string;
+}
+
 export const AttestationsQuery = `
   query Attestations($where: AttestationWhereInput, $orderBy: [AttestationOrderByWithRelationInput!], $take: Int, $skip: Int) {
     attestations(take: $take, skip: $skip, orderBy: $orderBy, where: $where) {
@@ -144,6 +149,20 @@ export interface Poll {
      */
     metadataUrl: string;
   };
+}
+
+/**
+ * The tally data
+ */
+export interface Tally {
+  /**
+   * The tally address
+   */
+  id: string;
+  /**
+   * an array with the results
+   */
+  results: TallyResult[];
 }
 
 /**


### PR DESCRIPTION
How to use:

```js
import { api } from "~/utils/api";
...
const tally = api.maci.tally.useQuery({ id: "TallyContractAddress" });
// Use the results from the tally.
```