### PR TITLE
chore: remove caching for synpress runs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -58,8 +58,6 @@ jobs:
           path: |
             ~/.pnpm-store
             node_modules
-            /home/runner/.cache/Cypress
-            packages/e2e/.cache-synpress
           key: ${{ runner.os }}-node-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-node-


### PR DESCRIPTION
Disable cache for synpress run to avoid issues with old version tests