### PR TITLE
feat: update single round UI and slightly update the mobile UI

### DIFF
--- a/packages/interface/src/components/ConnectButton.tsx
+++ b/packages/interface/src/components/ConnectButton.tsx
@@ -1,13 +1,13 @@
 import { ConnectButton as RainbowConnectButton } from "@rainbow-me/rainbowkit";
+import dynamic from "next/dynamic";
 import Image from "next/image";
-import { createBreakpoint } from "react-use";
+import { useMemo } from "react";
 
 import { config } from "~/config";
+import { useIsMobile } from "~/hooks/useIsMobile";
 
 import { Button } from "./ui/Button";
 import { Chip } from "./ui/Chip";
-
-const useBreakpoint = createBreakpoint({ XL: 1280, L: 768, S: 350 });
 
 interface IConnectedDetailsProps {
   account: { address: string; displayName: string; ensName?: string };
@@ -31,11 +31,16 @@ const ConnectedDetails = ({ openAccountModal, account, isMobile }: IConnectedDet
   );
 };
 
-export const ConnectButton = (): JSX.Element => {
-  const breakpoint = useBreakpoint();
-  const isMobile = breakpoint === "S";
+interface IConnectButtonProps {
+  showMobile: boolean;
+}
 
-  return (
+const ConnectButton = ({ showMobile }: IConnectButtonProps): JSX.Element | null => {
+  const isMobile = useIsMobile();
+
+  const isShow = useMemo(() => showMobile === isMobile, [isMobile, showMobile]);
+
+  return isShow ? (
     <RainbowConnectButton.Custom>
       {({ account, chain, openAccountModal, openChainModal, openConnectModal, mounted, authenticationStatus }) => {
         const ready = mounted && authenticationStatus !== "loading";
@@ -57,7 +62,7 @@ export const ConnectButton = (): JSX.Element => {
               if (!connected) {
                 return (
                   <Button suppressHydrationWarning variant="secondary" onClick={openConnectModal}>
-                    {isMobile ? "Connect" : "Connect wallet"}
+                    <p>Connect wallet</p>
                   </Button>
                 );
               }
@@ -70,11 +75,13 @@ export const ConnectButton = (): JSX.Element => {
                 );
               }
 
-              return <ConnectedDetails account={account} isMobile={isMobile} openAccountModal={openAccountModal} />;
+              return <ConnectedDetails account={account} isMobile={false} openAccountModal={openAccountModal} />;
             })()}
           </div>
         );
       }}
     </RainbowConnectButton.Custom>
-  );
+  ) : null;
 };
+
+export default dynamic(async () => Promise.resolve(ConnectButton), { ssr: false });

--- a/packages/interface/src/components/Header.tsx
+++ b/packages/interface/src/components/Header.tsx
@@ -10,7 +10,7 @@ import { useBallot } from "~/contexts/Ballot";
 import { useRoundState } from "~/utils/state";
 import { ERoundState } from "~/utils/types";
 
-import { ConnectButton } from "./ConnectButton";
+import ConnectButton from "./ConnectButton";
 import { IconButton } from "./ui/Button";
 import { Logo } from "./ui/Logo";
 
@@ -122,7 +122,7 @@ const Header = ({ navLinks, pollId = "" }: IHeaderProps) => {
             onClick={handleChangeTheme}
           />
 
-          <ConnectButton />
+          <ConnectButton showMobile={false} />
         </div>
 
         <MobileMenu isOpen={isOpen} navLinks={navLinks} />

--- a/packages/interface/src/components/Info.tsx
+++ b/packages/interface/src/components/Info.tsx
@@ -18,7 +18,7 @@ const InfoContainer = createComponent(
     variants: {
       size: {
         sm: "flex-col",
-        default: "flex-col max-lg:w-full lg:flex-row",
+        default: "flex-col max-lg:w-full xl:flex-row xl:w-fit",
       },
     },
   }),
@@ -73,7 +73,7 @@ export const Info = ({
   ];
 
   return (
-    <div className="w-full">
+    <div className="flex w-full justify-center">
       <InfoContainer size={size}>
         {showRoundInfo && <RoundInfo roundId={round?.roundId ?? ""} />}
 

--- a/packages/interface/src/components/SingleRoundHome.tsx
+++ b/packages/interface/src/components/SingleRoundHome.tsx
@@ -1,0 +1,50 @@
+import { useAccount } from "wagmi";
+
+import ConnectButton from "~/components/ConnectButton";
+import { Info } from "~/components/Info";
+import { JoinButton } from "~/components/JoinButton";
+import { Button } from "~/components/ui/Button";
+import { Heading } from "~/components/ui/Heading";
+import { useMaci } from "~/contexts/Maci";
+import { useIsMobile } from "~/hooks/useIsMobile";
+import { useRoundState } from "~/utils/state";
+import { ERoundState, type IRoundData } from "~/utils/types";
+
+interface ISingleRoundHomeProps {
+  round: IRoundData;
+}
+
+export const SingleRoundHome = ({ round }: ISingleRoundHomeProps): JSX.Element => {
+  const { isConnected } = useAccount();
+  const { isRegistered } = useMaci();
+  const isMobile = useIsMobile();
+  const roundState = useRoundState({ pollId: round.pollId });
+
+  return (
+    <div className="flex h-auto w-screen flex-col items-center justify-center gap-4 bg-blue-50 px-2 pb-4 sm:h-[90vh] dark:bg-black">
+      <Heading className="mb-0 mt-4 max-w-screen-lg text-center sm:mt-0" size="6xl">
+        {round.roundId}
+      </Heading>
+
+      <p className="text-gray-400">{round.description}</p>
+
+      <Button size="auto" variant={roundState === ERoundState.RESULTS ? "tertiary" : "secondary"}>
+        <a href={`/rounds/${round.pollId}`}>View Projects</a>
+      </Button>
+
+      {roundState === ERoundState.RESULTS && (
+        <Button size="auto" variant="primary">
+          <a href={`/rounds/${round.pollId}`}>View Results</a>
+        </Button>
+      )}
+
+      {!isConnected && !isMobile && <p className="text-gray-400">Connect your wallet to get started.</p>}
+
+      {(roundState === ERoundState.APPLICATION || roundState === ERoundState.VOTING) && <ConnectButton showMobile />}
+
+      {isConnected && !isRegistered && <JoinButton />}
+
+      <Info showAppState pollId={round.pollId} showBallot={false} showRoundInfo={false} size="default" />
+    </div>
+  );
+};

--- a/packages/interface/src/hooks/useIsMobile.ts
+++ b/packages/interface/src/hooks/useIsMobile.ts
@@ -1,0 +1,15 @@
+import { createBreakpoint } from "react-use";
+
+import { EBreakpointSizes } from "~/utils/types";
+
+export function useIsMobile(): boolean {
+  const useBreakpoint = createBreakpoint({
+    XL: EBreakpointSizes.XL,
+    L: EBreakpointSizes.L,
+    M: EBreakpointSizes.M,
+    S: EBreakpointSizes.S,
+  });
+  const breakpoint = useBreakpoint();
+
+  return breakpoint === "S";
+}

--- a/packages/interface/src/pages/index.tsx
+++ b/packages/interface/src/pages/index.tsx
@@ -1,6 +1,9 @@
+import { useMemo } from "react";
 import { useAccount } from "wagmi";
 
+import ConnectButton from "~/components/ConnectButton";
 import { JoinButton } from "~/components/JoinButton";
+import { SingleRoundHome } from "~/components/SingleRoundHome";
 import { Button } from "~/components/ui/Button";
 import { Heading } from "~/components/ui/Heading";
 import { config } from "~/config";
@@ -16,38 +19,45 @@ const HomePage = (): JSX.Element => {
   const { isRegistered } = useMaci();
   const isAdmin = useIsAdmin();
   const { rounds } = useRound();
+  const singleRound = useMemo(() => rounds?.[0], [rounds]);
 
   return (
-    <Layout type="home">
-      <div className="flex h-auto w-screen flex-col items-center justify-center gap-4 bg-blue-50 px-2 sm:h-[90vh] dark:bg-black">
-        <Heading className="mt-4 max-w-screen-lg text-center sm:mt-0" size="6xl">
-          {config.eventName}
-        </Heading>
+    <Layout pollId={singleRound ? singleRound.pollId : ""} type="home">
+      {singleRound && <SingleRoundHome round={singleRound} />}
 
-        <Heading className="max-w-screen-lg text-center" size="3xl">
-          {config.eventDescription}
-        </Heading>
+      {!singleRound && (
+        <div className="flex h-auto w-screen flex-col items-center justify-center gap-4 bg-blue-50 px-2 pb-4 sm:h-[90vh] dark:bg-black">
+          <Heading className="mt-4 max-w-screen-lg text-center sm:mt-0" size="6xl">
+            {config.eventName}
+          </Heading>
 
-        {!isConnected && <p className="text-gray-400">Connect your wallet to get started.</p>}
+          <Heading className="max-w-screen-lg text-center" size="3xl">
+            {config.eventDescription}
+          </Heading>
 
-        {isConnected && !isRegistered && <JoinButton />}
+          {!isConnected && <p className="text-gray-400">Connect your wallet to get started.</p>}
 
-        {isConnected && isAdmin && (
-          <div className="flex flex-col gap-4">
-            <p className="text-gray-400">Configure and deploy your contracts to get started.</p>
+          <ConnectButton showMobile />
 
-            <Button size="auto" variant="primary">
-              <a href="/coordinator">Get Started</a>
-            </Button>
-          </div>
-        )}
+          {isConnected && !isRegistered && <JoinButton />}
 
-        {isConnected && !isAdmin && rounds && rounds.length === 0 && (
-          <p className="text-gray-400">There are no rounds deployed.</p>
-        )}
+          {isConnected && isAdmin && (
+            <div className="flex flex-col gap-4">
+              <p className="text-center text-gray-400">Configure and deploy your contracts to get started.</p>
 
-        {rounds && rounds.length > 0 && <RoundsList />}
-      </div>
+              <Button size="auto" variant="primary">
+                <a href="/coordinator">Get Started</a>
+              </Button>
+            </div>
+          )}
+
+          {isConnected && !isAdmin && rounds && rounds.length === 0 && (
+            <p className="text-gray-400">There are no rounds deployed.</p>
+          )}
+
+          {rounds && rounds.length > 1 && <RoundsList />}
+        </div>
+      )}
 
       <FAQList />
     </Layout>

--- a/packages/interface/src/utils/types.ts
+++ b/packages/interface/src/utils/types.ts
@@ -16,6 +16,13 @@ export enum EInfoCardState {
   UPCOMING = "UPCOMING",
 }
 
+export enum EBreakpointSizes {
+  S = 320,
+  M = 480,
+  L = 768,
+  XL = 1280,
+}
+
 export interface AttestationWithMetadata {
   id: string;
   refUID: string;

--- a/packages/subgraph/package.json
+++ b/packages/subgraph/package.json
@@ -18,7 +18,7 @@
     "generate:schema": "cp ./schemas/schema.${VERSION:-v1}.graphql schema.graphql",
     "prebuild": "pnpm codegen",
     "build": "graph build",
-    "deploy": "graph deploy --node https://api.studio.thegraph.com/deploy/ maci",
+    "deploy": "graph deploy --node https://api.studio.thegraph.com/deploy/ maci-subgraph",
     "create-local": "graph create --node http://localhost:8020/ maci-subgraph",
     "remove-local": "graph remove --node http://localhost:8020/ maci-subgraph",
     "deploy-local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 maci-subgraph --network localhost",


### PR DESCRIPTION
**Description**
Since there's need for only running single round, add the single round UI back but slightly modify the displayed information and alignment.

- [x] fix some mobile display issues
- [x] add `Info` component back on the main page while there's only 1 round
- [x] add `view projects` button no matter the user signed up or not
- [x] add `view results` button for user to quickly go the result page if the result is revealed
- [x] move the `connect wallet` button from top-right to the center of the page while it's mobile
- [x] better align the mentioned buttons
- [x] put back sign up button for single round