### PR TITLE
fix: catch error for fetch subgraph

### DIFF
--- a/packages/interface/src/utils/fetchTally.ts
+++ b/packages/interface/src/utils/fetchTally.ts
@@ -48,7 +48,9 @@ export async function fetchTally(id: string): Promise<Tally | undefined> {
     body: JSON.stringify({
       query: tallyQuery.replace("id: $id", `id: "${id}"`),
     }),
-  }).then((response: GraphQLResponse) => response.data?.tally);
+  })
+    .then((response: GraphQLResponse) => response.data?.tally)
+    .catch(() => undefined);
 }
 
 /**
@@ -62,5 +64,7 @@ export async function fetchTallies(): Promise<Tally[] | undefined> {
     body: JSON.stringify({
       query: talliesQuery,
     }),
-  }).then((r) => r.data.tallies);
+  })
+    .then((r) => r.data.tallies)
+    .catch(() => []);
 }


### PR DESCRIPTION
**Description**

- [x] if there's an error for `fetchTally`, return empty array `[]`
- [x] check all the subgraph fetch function and wrap them with `catch` error or not causing any error

**Related Issues**
close #526 