### PR TITLE
feat: display the projects created by the user

### DIFF
--- a/packages/interface/src/features/applications/components/ApplicationForm.tsx
+++ b/packages/interface/src/features/applications/components/ApplicationForm.tsx
@@ -1,6 +1,5 @@
 import { useRouter } from "next/router";
 import { useState, useCallback } from "react";
-import { useLocalStorage } from "react-use";
 import { toast } from "sonner";
 import { useAccount } from "wagmi";
 
@@ -22,8 +21,6 @@ interface IApplicationFormProps {
 }
 
 export const ApplicationForm = ({ pollId }: IApplicationFormProps): JSX.Element => {
-  const clearDraft = useLocalStorage("application-draft")[2];
-
   const { isCorrectNetwork, correctNetwork } = useIsCorrectNetwork();
 
   const { address } = useAccount();
@@ -56,7 +53,6 @@ export const ApplicationForm = ({ pollId }: IApplicationFormProps): JSX.Element 
 
   const create = useCreateApplication({
     onSuccess: (id: bigint) => {
-      clearDraft();
       router.push(`/rounds/${pollId}/applications/confirmation?id=${id.toString()}`);
     },
     onError: (err: { message: string }) =>

--- a/packages/interface/src/features/applications/components/ReviewApplicationDetails.tsx
+++ b/packages/interface/src/features/applications/components/ReviewApplicationDetails.tsx
@@ -3,6 +3,7 @@ import { useMemo, type ReactNode } from "react";
 import { useFormContext } from "react-hook-form";
 import Markdown from "react-markdown";
 import { Hex } from "viem";
+import { useAccount } from "wagmi";
 
 import { Heading } from "~/components/ui/Heading";
 import { Tag } from "~/components/ui/Tag";
@@ -64,6 +65,8 @@ export const ReviewApplicationDetails = (): JSX.Element => {
 
   const application = useMemo(() => form.getValues(), [form]);
 
+  const { address } = useAccount();
+
   return (
     <div className="markdown-support flex flex-col gap-8">
       <div>
@@ -76,6 +79,8 @@ export const ReviewApplicationDetails = (): JSX.Element => {
         <b className="text-lg">Project Profile</b>
 
         <ValueField required body={application.name} title="Project name" />
+
+        <ValueField required body={address} title="Created By" />
 
         <MarkdownField required body={<Markdown>{application.bio}</Markdown>} title="Project description" />
 

--- a/packages/interface/src/features/applications/hooks/useApplicationById.ts
+++ b/packages/interface/src/features/applications/hooks/useApplicationById.ts
@@ -1,8 +1,0 @@
-import { api } from "~/utils/api";
-
-import type { UseTRPCQueryResult } from "@trpc/react-query/shared";
-import type { IRequest } from "~/utils/types";
-
-export function useApplicationById(registryAddress: string, id: string): UseTRPCQueryResult<IRequest, unknown> {
-  return api.applications.getById.useQuery({ registryAddress, id });
-}

--- a/packages/interface/src/features/applications/hooks/useApplications.ts
+++ b/packages/interface/src/features/applications/hooks/useApplications.ts
@@ -1,7 +1,7 @@
 import { api } from "~/utils/api";
 
 import type { UseTRPCQueryResult } from "@trpc/react-query/shared";
-import type { IRequest } from "~/utils/types";
+import type { IRequest, IRecipient } from "~/utils/types";
 
 export function useApprovedApplications(registryAddress: string): UseTRPCQueryResult<IRequest[], unknown> {
   return api.applications.approvals.useQuery({ registryAddress });
@@ -16,4 +16,20 @@ export function useApplicationByProjectId(
   registryAddress: string,
 ): UseTRPCQueryResult<IRequest, unknown> {
   return api.applications.getByProjectId.useQuery({ projectId, registryAddress });
+}
+
+export function useAllApplications(registryAddress: string): UseTRPCQueryResult<IRequest, unknown> {
+  return api.applications.getByIds.useQuery({ registryAddress, ids: [] });
+}
+
+export function useApplicationById(registryAddress: string, id: string): UseTRPCQueryResult<IRequest, unknown> {
+  return api.applications.getById.useQuery({ registryAddress, id });
+}
+
+export function useApplicationsByIds(registryAddress: string, ids: string[]): UseTRPCQueryResult<IRequest[], unknown> {
+  return api.applications.getByIds.useQuery({ registryAddress, ids });
+}
+
+export function useMyApplications(registryAddress: string, address: string): UseTRPCQueryResult<IRecipient[], unknown> {
+  return api.projects.getMine.useQuery({ registryAddress, address });
 }

--- a/packages/interface/src/features/applications/hooks/useCreateApplication.ts
+++ b/packages/interface/src/features/applications/hooks/useCreateApplication.ts
@@ -34,7 +34,7 @@ export function useCreateApplication(options: {
 }): TUseCreateApplicationReturn {
   const upload = useUploadMetadata();
 
-  const { chain } = useAccount();
+  const { chain, address } = useAccount();
   const { getRoundByPollId } = useRound();
 
   const roundData = getRoundByPollId(options.pollId);
@@ -44,7 +44,7 @@ export function useCreateApplication(options: {
 
   const mutation = useMutation({
     mutationFn: async (values: Application) => {
-      if (!signer || !chain) {
+      if (!signer || !chain || !address) {
         throw new Error("Please connect your wallet first");
       }
 
@@ -71,6 +71,7 @@ export function useCreateApplication(options: {
         profileImageUrl: profileImageUrl.url,
         bannerImageUrl: bannerImageUrl.url,
         submittedAt: Date.now().valueOf(),
+        creator: address,
       };
 
       const uploadRes = await upload.mutateAsync(metadataValues);

--- a/packages/interface/src/features/applications/types/index.ts
+++ b/packages/interface/src/features/applications/types/index.ts
@@ -25,6 +25,7 @@ export const fundingSourceTypes = {
 export const ApplicationSchema = z.object({
   name: z.string().min(3),
   bio: z.string().min(3),
+  creator: z.string().optional(),
   profileImageUrl: z.string().optional(),
   bannerImageUrl: z.string().optional(),
   submittedAt: z.number().optional(),

--- a/packages/interface/src/features/projects/components/ProjectItem.tsx
+++ b/packages/interface/src/features/projects/components/ProjectItem.tsx
@@ -1,4 +1,5 @@
 import Image from "next/image";
+import Link from "next/link";
 
 import { Button } from "~/components/ui/Button";
 import { Heading } from "~/components/ui/Heading";
@@ -42,57 +43,59 @@ export const ProjectItem = ({
   const impactCategory = recipient.impactCategory ? recipient.impactCategory : metadata.data?.impactCategory;
 
   return (
-    <article
-      className="dark:bg-lightBlack group w-96 rounded-xl bg-white shadow-lg hover:shadow-sm sm:w-full"
-      data-testid={`project-${recipient.id}`}
-    >
-      <div className="opacity-70 transition-opacity group-hover:opacity-100">
-        <ProjectBanner url={bannerImageUrl} />
+    <Link href={`/rounds/${pollId}/${recipient.id}`}>
+      <article
+        className="dark:bg-lightBlack group w-96 rounded-xl bg-white shadow-lg hover:shadow-sm sm:w-full"
+        data-testid={`project-${recipient.id}`}
+      >
+        <div className="opacity-70 transition-opacity group-hover:opacity-100">
+          <ProjectBanner url={bannerImageUrl} />
 
-        <ProjectAvatar className="-mt-8 ml-4" rounded="full" url={profileImageUrl} />
-      </div>
-
-      <div className="p-4 pt-2">
-        <Heading as="h3" className="truncate dark:text-white" size="lg">
-          <Skeleton isLoading={isLoading}>{name}</Skeleton>
-        </Heading>
-
-        <div className="mb-2 line-clamp-2 h-10 text-sm text-gray-400">
-          <Skeleton className="w-full" isLoading={isLoading}>
-            {removeMarkdown(bio || "")}
-          </Skeleton>
+          <ProjectAvatar className="-mt-8 ml-4" rounded="full" url={profileImageUrl} />
         </div>
 
-        <Skeleton className="w-[100px]" isLoading={isLoading}>
-          <ImpactCategories tags={impactCategory} />
-        </Skeleton>
+        <div className="p-4 pt-2">
+          <Heading as="h3" className="truncate dark:text-white" size="lg">
+            <Skeleton isLoading={isLoading}>{name}</Skeleton>
+          </Heading>
 
-        {!isLoading && state !== undefined && action && roundState === ERoundState.VOTING && (
-          <div className="flex justify-end pt-6">
-            <Skeleton>
-              {state === EProjectState.DEFAULT && (
-                <Button size="sm" variant="inverted" onClick={action}>
-                  Add to ballot
-                </Button>
-              )}
-
-              {state === EProjectState.ADDED && (
-                <Button size="sm" variant="primary" onClick={action}>
-                  Added
-                  <Image alt="check-white" height="18" src="/check-white.svg" width="18" />
-                </Button>
-              )}
-
-              {state === EProjectState.SUBMITTED && (
-                <Button size="sm" variant="disabled">
-                  Submitted
-                </Button>
-              )}
+          <div className="mb-2 line-clamp-2 h-10 text-sm text-gray-400">
+            <Skeleton className="w-full" isLoading={isLoading}>
+              {removeMarkdown(bio || "")}
             </Skeleton>
           </div>
-        )}
-      </div>
-    </article>
+
+          <Skeleton className="w-[100px]" isLoading={isLoading}>
+            <ImpactCategories tags={impactCategory} />
+          </Skeleton>
+
+          {!isLoading && state !== undefined && action && roundState === ERoundState.VOTING && (
+            <div className="flex justify-end pt-6">
+              <Skeleton>
+                {state === EProjectState.DEFAULT && (
+                  <Button size="sm" variant="inverted" onClick={action}>
+                    Add to ballot
+                  </Button>
+                )}
+
+                {state === EProjectState.ADDED && (
+                  <Button size="sm" variant="primary" onClick={action}>
+                    Added
+                    <Image alt="check-white" height="18" src="/check-white.svg" width="18" />
+                  </Button>
+                )}
+
+                {state === EProjectState.SUBMITTED && (
+                  <Button size="sm" variant="disabled">
+                    Submitted
+                  </Button>
+                )}
+              </Skeleton>
+            </div>
+          )}
+        </div>
+      </article>
+    </Link>
   );
 };
 

--- a/packages/interface/src/features/projects/components/ProjectsResults.tsx
+++ b/packages/interface/src/features/projects/components/ProjectsResults.tsx
@@ -1,5 +1,4 @@
 import clsx from "clsx";
-import Link from "next/link";
 import { useRouter } from "next/router";
 import { useCallback, useMemo } from "react";
 import { type Hex, zeroAddress } from "viem";
@@ -43,11 +42,7 @@ export const ProjectsResults = ({ pollId }: IProjectsResultsProps): JSX.Element 
     <InfiniteLoading
       {...projects}
       renderItem={(item, { isLoading }) => (
-        <Link
-          key={item.id}
-          className={clsx("relative", { "animate-pulse": isLoading })}
-          href={`/rounds/${pollId}/${item.id}`}
-        >
+        <div key={item.id} className={clsx("relative", { "animate-pulse": isLoading })}>
           {!results.isLoading && roundState === ERoundState.RESULTS ? (
             <ProjectItemAwarded amount={results.data?.projects[item.id]?.votes} />
           ) : null}
@@ -59,7 +54,7 @@ export const ProjectsResults = ({ pollId }: IProjectsResultsProps): JSX.Element 
             recipient={item}
             state={EProjectState.SUBMITTED}
           />
-        </Link>
+        </div>
       )}
     />
   );

--- a/packages/interface/src/features/rounds/components/Projects.tsx
+++ b/packages/interface/src/features/rounds/components/Projects.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { useCallback, useMemo } from "react";
 import { FiAlertCircle } from "react-icons/fi";
 import { Hex, zeroAddress } from "viem";
+import { useAccount } from "wagmi";
 
 import { InfiniteLoading } from "~/components/InfiniteLoading";
 import { SortFilter } from "~/components/SortFilter";
@@ -12,6 +13,7 @@ import { Heading } from "~/components/ui/Heading";
 import { useBallot } from "~/contexts/Ballot";
 import { useMaci } from "~/contexts/Maci";
 import { useRound } from "~/contexts/Round";
+import { useMyApplications } from "~/features/applications/hooks/useApplications";
 import { useResults } from "~/hooks/useResults";
 import { useRoundState } from "~/utils/state";
 import { ERoundState } from "~/utils/types";
@@ -26,6 +28,8 @@ export interface IProjectsProps {
 
 export const Projects = ({ pollId = "" }: IProjectsProps): JSX.Element => {
   const roundState = useRoundState({ pollId });
+
+  const { address } = useAccount();
 
   const { getRoundByPollId } = useRound();
   const round = useMemo(() => getRoundByPollId(pollId), [pollId, getRoundByPollId]);
@@ -42,6 +46,13 @@ export const Projects = ({ pollId = "" }: IProjectsProps): JSX.Element => {
   );
 
   const ballot = useMemo(() => getBallot(pollId), [pollId, getBallot]);
+
+  /**
+   *  Find my applications: "I" am either the "creator" or the "payout address"
+   */
+  const applications = useMyApplications(round?.registryAddress ?? zeroAddress, address ?? zeroAddress);
+
+  const myApplications = useMemo(() => applications.data, [applications]);
 
   const handleAction = useCallback(
     (projectIndex: number, projectId: string) => (e: Event) => {
@@ -118,24 +129,36 @@ export const Projects = ({ pollId = "" }: IProjectsProps): JSX.Element => {
         </div>
       </div>
 
-      {roundState === ERoundState.APPLICATION && (
-        <div className="mb-4 flex w-full justify-end">
-          <Link href={`/rounds/${pollId}/applications/new`}>
-            <Button size="auto" variant="primary">
-              Create Application
-            </Button>
-          </Link>
+      {roundState === ERoundState.APPLICATION && address && (
+        <div className="mb-4 rounded-md border border-black p-4 dark:border-white">
+          <div className="flex justify-between">
+            <Heading size="xl">My Projects</Heading>
+
+            <Link href={`/rounds/${pollId}/applications/new`}>
+              <Button size="auto" variant="primary">
+                Create Application
+              </Button>
+            </Link>
+          </div>
+
+          <div className="my-4 gap-4 md:grid md:grid-cols-2 lg:grid lg:grid-cols-3">
+            {myApplications &&
+              myApplications.length > 0 &&
+              myApplications.map((project) => (
+                <ProjectItem key={project.id} isLoading={false} pollId={pollId} recipient={project} />
+              ))}
+
+            {(!myApplications || myApplications.length === 0) && (
+              <p className="text-gray-400">Create your application by clicking the button</p>
+            )}
+          </div>
         </div>
       )}
 
       <InfiniteLoading
         {...projects}
         renderItem={(item, { isLoading }) => (
-          <Link
-            key={item.id}
-            className={clsx("relative", { "animate-pulse": isLoading })}
-            href={`/rounds/${pollId}/${item.id}`}
-          >
+          <div key={item.id} className={clsx("relative", { "animate-pulse": isLoading })}>
             {!results.isLoading && roundState === ERoundState.RESULTS ? (
               <ProjectItemAwarded amount={results.data?.projects[item.id]?.votes} />
             ) : null}
@@ -147,7 +170,7 @@ export const Projects = ({ pollId = "" }: IProjectsProps): JSX.Element => {
               recipient={item}
               state={defineState(Number.parseInt(item.index, 10))}
             />
-          </Link>
+          </div>
         )}
       />
     </div>

--- a/packages/interface/src/hooks/useRegistry.ts
+++ b/packages/interface/src/hooks/useRegistry.ts
@@ -22,7 +22,7 @@ interface SubmitApplicationArgs {
    */
   registryAddress: Hex;
   /**
-   * The recipient of the attestation
+   * The recipient of the application
    */
   recipient: Hex;
 }

--- a/packages/interface/src/pages/rounds/[pollId]/applications/confirmation.tsx
+++ b/packages/interface/src/pages/rounds/[pollId]/applications/confirmation.tsx
@@ -1,4 +1,3 @@
-import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { useMemo } from "react";
 import { FiAlertCircle } from "react-icons/fi";
@@ -8,7 +7,7 @@ import { EmptyState } from "~/components/EmptyState";
 import { Alert } from "~/components/ui/Alert";
 import { Heading } from "~/components/ui/Heading";
 import { useRound } from "~/contexts/Round";
-import { useApplicationById } from "~/features/applications/hooks/useApplicationById";
+import { useApplicationById } from "~/features/applications/hooks/useApplications";
 import { ProjectItem } from "~/features/projects/components/ProjectItem";
 import { Layout } from "~/layouts/DefaultLayout";
 import { useRoundState } from "~/utils/state";
@@ -83,9 +82,7 @@ const ConfirmProjectPage = ({ pollId }: { pollId: string }): JSX.Element => {
             </div>
           )}
 
-          <Link href={`/rounds/${pollId}/${project.recipient.id}`}>
-            <ProjectItem isLoading={false} pollId={pollId} recipient={project.recipient as IRecipient} />
-          </Link>
+          <ProjectItem isLoading={false} pollId={pollId} recipient={project.recipient as IRecipient} />
         </div>
       </div>
     </Layout>

--- a/packages/interface/src/server/api/routers/applications.ts
+++ b/packages/interface/src/server/api/routers/applications.ts
@@ -6,18 +6,31 @@ import {
   fetchApplicationByProjectId,
   fetchApprovedApplications,
   fetchPendingApplications,
+  fetchApplications,
 } from "~/utils/fetchApplications";
 
 export const applicationsRouter = createTRPCRouter({
   approvals: publicProcedure
     .input(z.object({ registryAddress: z.string() }))
     .query(async ({ input }) => fetchApprovedApplications(input.registryAddress)),
+
   pending: publicProcedure
     .input(z.object({ registryAddress: z.string() }))
     .query(async ({ input }) => fetchPendingApplications(input.registryAddress)),
+
   getById: publicProcedure
     .input(z.object({ registryAddress: z.string(), id: z.string() }))
     .query(async ({ input }) => fetchApplicationById(input.registryAddress, input.id)),
+
+  getByIds: publicProcedure
+    .input(z.object({ registryAddress: z.string(), ids: z.array(z.string()) }))
+    .query(async ({ input }) => {
+      if (input.ids.length > 0) {
+        return Promise.all(input.ids.map((id) => fetchApplicationById(input.registryAddress, id)));
+      }
+      return fetchApplications(input.registryAddress);
+    }),
+
   getByProjectId: publicProcedure
     .input(z.object({ registryAddress: z.string(), projectId: z.string() }))
     .query(async ({ input }) => fetchApplicationByProjectId(input.projectId, input.registryAddress)),

--- a/packages/interface/src/server/api/routers/projects.ts
+++ b/packages/interface/src/server/api/routers/projects.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 
 import { FilterSchema } from "~/features/filter/types";
 import { createTRPCRouter, publicProcedure } from "~/server/api/trpc";
-import { fetchApprovedProjects, fetchProjects } from "~/utils/fetchProjects";
+import { fetchApprovedProjects, fetchProjects, fetchProjectsByAddress } from "~/utils/fetchProjects";
 import { getProjectCount } from "~/utils/registry";
 
 import type { Chain, Hex } from "viem";
@@ -38,6 +38,10 @@ export const projectsRouter = createTRPCRouter({
   projects: publicProcedure
     .input(FilterSchema.extend({ registryAddress: z.string() }))
     .query(async ({ input }) => fetchProjects(input.registryAddress)),
+
+  getMine: publicProcedure
+    .input(z.object({ registryAddress: z.string(), address: z.string() }))
+    .query(async ({ input }) => fetchProjectsByAddress(input.registryAddress, input.address)),
 
   // Used for distribution to get the projects' payoutAddress
   // To get this data we need to fetch all projects and their metadata

--- a/packages/interface/src/utils/fetchApplications.ts
+++ b/packages/interface/src/utils/fetchApplications.ts
@@ -65,6 +65,25 @@ const ApprovedRequests = `
   }
 `;
 
+// Fetch all add requests
+const AllRequests = `
+  query AllRequests($registryAddress: String!) {
+    requests(where: { requestType: "Add", recipient_: { registry: $registryAddress } }) {
+      index
+      recipient {
+        id
+        metadataUrl
+        index
+        initialized
+        payout
+        registry {
+          id
+        }
+      }
+    }
+  }
+`;
+
 const IndividualRequest = `
   query PendingAddRequests($registryAddress: String!, $recipientId: String!) {
     requests(where: { requestType: "Add", status: "Pending", recipient_: { 
@@ -226,7 +245,7 @@ export async function fetchApplications(registryAddress: string): Promise<IReque
       "Content-Type": "application/json",
     },
     body: JSON.stringify({
-      query: ApprovedRequests,
+      query: AllRequests,
       variables: { registryAddress },
     }),
   });

--- a/packages/interface/src/utils/fetchProjects.ts
+++ b/packages/interface/src/utils/fetchProjects.ts
@@ -40,6 +40,21 @@ const Projects = `
     }
   }`;
 
+const ProjectsByAddress = `
+  query ApplicationsByAddress($registryAddress: String!, $address: String!) {
+    recipients(where: { registry: $registryAddress, payout: $address  }) {
+      id
+      metadataUrl
+      index
+      initialized
+      payout
+      registry {
+        id
+      }
+    }
+  }
+`;
+
 /**
  * Fetch all projects
  *
@@ -88,4 +103,25 @@ export async function fetchApprovedProjects(registryAddress: string): Promise<IR
   }));
 
   return recipients ?? [];
+}
+
+export async function fetchProjectsByAddress(registryAddress: string, address: string): Promise<IRecipient[]> {
+  const response = await fetch(config.maciSubgraphUrl, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      query: ProjectsByAddress,
+      variables: { registryAddress, address },
+    }),
+  });
+
+  const result = (await response.json()) as GraphQLResponse;
+
+  if (!result.data) {
+    throw new Error("No data returned from GraphQL query");
+  }
+
+  return result.data.recipients;
 }


### PR DESCRIPTION
**Description**
This PR is trying to figure out what is the best way to display the projects to the user during the application registration period, since they might wanna check if their application is approved or not, and they might want to edit it.

Method 1: (Which is now implemented in this PR)
store user's projectId in the localStorage, load those projects separately and display on the top area of the project dashboard.
<img width="1417" alt="image" src="https://github.com/user-attachments/assets/ce6fa0c9-c07b-47e2-b712-30a317dcf43d">
- Why store the ids in the localStorage? because the one upload this project might not be the one holding that payout address
- Why display in a separate area instead of display them altogether but just add a highlight border or tag on it? we could discuss more about it, **display in a separate block** or **display altogether with other approved projects**
- Why the approved application by the user is displayed both in the separate block and in all projects? this should also be discussed, the reason why I did this is because imagine there are hundreds of projects there but user still wanna check their approved projects
- Why not just adjust the sorting and put the projects created by the user always on the top? is also a good idea, but maybe we need to add something to let user know exactly these are their projects?

**Related Issues**
close #514 