### PR TITLE
fix: ballot page refresh redirect to homepage

### DIFF
--- a/packages/interface/src/layouts/BaseLayout.tsx
+++ b/packages/interface/src/layouts/BaseLayout.tsx
@@ -9,7 +9,6 @@ import { useAccount } from "wagmi";
 import { Footer } from "~/components/Footer";
 import { createComponent } from "~/components/ui";
 import { metadata } from "~/config";
-import { useMaci } from "~/contexts/Maci";
 
 import type { IBaseLayoutProps } from "./types";
 
@@ -50,7 +49,6 @@ export const BaseLayout = ({
   sidebar = undefined,
   sidebarComponent = null,
   requireAuth = false,
-  requireRegistration = false,
   eligibilityCheck = false,
   showBallot = false,
   type = undefined,
@@ -59,13 +57,12 @@ export const BaseLayout = ({
   const { theme } = useTheme();
   const router = useRouter();
   const { address, isConnecting } = useAccount();
-  const { isRegistered } = useMaci();
 
   const manageDisplay = useCallback(() => {
-    if ((requireAuth && !address && !isConnecting) || (requireRegistration && !isRegistered)) {
+    if (requireAuth && !address && !isConnecting) {
       router.push("/");
     }
-  }, [requireAuth, address, isConnecting, requireRegistration, isRegistered, router]);
+  }, [requireAuth, address, isConnecting, router]);
 
   useEffect(() => {
     manageDisplay();

--- a/packages/interface/src/layouts/types.ts
+++ b/packages/interface/src/layouts/types.ts
@@ -3,7 +3,6 @@ import type { ReactNode, PropsWithChildren } from "react";
 export interface LayoutProps {
   title?: string;
   requireAuth?: boolean;
-  requireRegistration?: boolean;
   eligibilityCheck?: boolean;
   showBallot?: boolean;
   type?: string;

--- a/packages/interface/src/pages/rounds/[pollId]/ballot/index.tsx
+++ b/packages/interface/src/pages/rounds/[pollId]/ballot/index.tsx
@@ -1,9 +1,7 @@
 import clsx from "clsx";
 import Link from "next/link";
-import { useRouter } from "next/router";
-import { useEffect, useState, useMemo, useCallback } from "react";
+import { useCallback, useState, useMemo } from "react";
 import { useFormContext } from "react-hook-form";
-import { useAccount } from "wagmi";
 
 import { Button } from "~/components/ui/Button";
 import { Dialog } from "~/components/ui/Dialog";
@@ -154,28 +152,21 @@ interface IBallotPageProps {
 }
 
 const BallotPage = ({ pollId }: IBallotPageProps): JSX.Element => {
-  const { address, isConnecting } = useAccount();
   const { getBallot, sumBallot } = useBallot();
   const { getRoundByPollId } = useRound();
-  const router = useRouter();
+  const { isRegistered } = useMaci();
   const roundState = useRoundState({ pollId });
 
   const round = useMemo(() => getRoundByPollId(pollId), [pollId, getRoundByPollId]);
   const ballot = useMemo(() => getBallot(pollId), [round?.pollId, getBallot]);
-
-  useEffect(() => {
-    if (!address && !isConnecting) {
-      router.push("/");
-    }
-  }, [address, isConnecting, router]);
 
   const handleSubmit = useCallback(() => {
     sumBallot();
   }, [sumBallot]);
 
   return (
-    <LayoutWithSidebar requireAuth requireRegistration showBallot showSubmitButton pollId={pollId} sidebar="right">
-      {roundState === ERoundState.VOTING && (
+    <LayoutWithSidebar requireAuth showBallot showSubmitButton pollId={pollId} sidebar="right">
+      {roundState === ERoundState.VOTING && isRegistered && (
         <Form defaultValues={ballot} schema={BallotSchema} values={ballot} onSubmit={handleSubmit}>
           <BallotAllocationForm mode={round!.mode} pollId={pollId} />
         </Form>
@@ -183,6 +174,10 @@ const BallotPage = ({ pollId }: IBallotPageProps): JSX.Element => {
 
       {roundState !== ERoundState.VOTING && (
         <div className="dark:text-white">You can only vote during the voting period.</div>
+      )}
+
+      {!isRegistered && (
+        <div className="dark:text-white">You must sign up to access the full information on this page.</div>
       )}
     </LayoutWithSidebar>
   );


### PR DESCRIPTION
**Description**
We add `requireRegistration` on the ballot page item, when refreshing, it takes time for the frontend to check if the user is registered or not. There should be another method deal with this condition instead of pushing them directly to the homepage.

**Related Issues**
close #540 