### PR TITLE
feat: display git commit version 

### DIFF
--- a/packages/interface/package.json
+++ b/packages/interface/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
+    "prebuild": "pnpm run git-hash",
     "build": "next build",
     "dev": "next dev",
     "lint": "next lint",
@@ -11,7 +12,8 @@
     "prettier": "prettier -c .",
     "prettier:fix": "prettier -w .",
     "types": "tsc -p tsconfig.json --noEmit",
-    "eas:registerSchemas": "npx tsx src/lib/eas/registerSchemas"
+    "eas:registerSchemas": "npx tsx src/lib/eas/registerSchemas",
+    "git-hash": "node ./scripts/genGitHash.js"
   },
   "dependencies": {
     "@ethereum-attestation-service/eas-sdk": "^2.7.0",

--- a/packages/interface/scripts/genGitHash.js
+++ b/packages/interface/scripts/genGitHash.js
@@ -1,0 +1,31 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+const { execSync } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+
+const commitHash = execSync('git log --pretty=format:"%h" -n1').toString().trim();
+
+const key = "NEXT_PUBLIC_COMMIT_HASH";
+
+const envFile = path.resolve(__dirname, "../.env");
+
+let data = "";
+if (fs.existsSync(envFile)) {
+  data = fs.readFileSync(envFile, "utf8");
+}
+
+const indexOfCommitHash = data.indexOf(key);
+
+if (indexOfCommitHash === -1) {
+  fs.writeFileSync(envFile, `${data}\n${key}=${commitHash}\n`, "utf8");
+} else {
+  const indexOfNextLine = data.indexOf("\n", indexOfCommitHash);
+  fs.writeFileSync(
+    envFile,
+    data
+      .slice(0, indexOfCommitHash)
+      .concat(data.slice(indexOfNextLine + 1))
+      .concat(`${key}=${commitHash}\n`),
+    "utf8",
+  );
+}

--- a/packages/interface/src/components/Footer.tsx
+++ b/packages/interface/src/components/Footer.tsx
@@ -2,6 +2,8 @@ import Image from "next/image";
 import { FaGithub, FaDiscord } from "react-icons/fa";
 import { FaXTwitter } from "react-icons/fa6";
 
+import { config } from "~/config";
+
 import { Logo } from "./ui/Logo";
 
 export const Footer = (): JSX.Element => (
@@ -26,6 +28,8 @@ export const Footer = (): JSX.Element => (
     </div>
 
     <div className="flex justify-end gap-4">
+      <p className="text-red flex items-center">Git Version: {config.commitHash}</p>
+
       <a className="flex items-center gap-1" href="https://maci.pse.dev" rel="noreferrer" target="_blank">
         <span>Docs</span>
 

--- a/packages/interface/src/config.ts
+++ b/packages/interface/src/config.ts
@@ -86,6 +86,7 @@ export const config = {
   roundLogo: process.env.NEXT_PUBLIC_ROUND_LOGO,
   semaphoreSubgraphUrl: process.env.NEXT_PUBLIC_SEMAPHORE_SUBGRAPH,
   treeUrl: process.env.NEXT_PUBLIC_TREE_URL,
+  commitHash: process.env.NEXT_PUBLIC_COMMIT_HASH,
 };
 
 export const theme = {

--- a/packages/interface/src/env.js
+++ b/packages/interface/src/env.js
@@ -52,6 +52,8 @@ module.exports = createEnv({
 
     NEXT_PUBLIC_SEMAPHORE_SUBGRAPH: z.string().url().optional(),
     NEXT_PUBLIC_TREE_URL: z.string().url().optional(),
+
+    NEXT_PUBLIC_COMMIT_HASH: z.string(),
   },
 
   /**
@@ -83,6 +85,8 @@ module.exports = createEnv({
 
     NEXT_PUBLIC_SEMAPHORE_SUBGRAPH: process.env.NEXT_PUBLIC_SEMAPHORE_SUBGRAPH,
     NEXT_PUBLIC_TREE_URL: process.env.NEXT_PUBLIC_TREE_URL,
+
+    NEXT_PUBLIC_COMMIT_HASH: process.env.NEXT_PUBLIC_COMMIT_HASH,
   },
   /**
    * Run `build` or `dev` with `SKIP_ENV_VALIDATION` to skip env validation. This is especially

--- a/packages/interface/src/pages/coordinator/index.tsx
+++ b/packages/interface/src/pages/coordinator/index.tsx
@@ -1,5 +1,14 @@
+import { config } from "~/config";
 import { Layout } from "~/layouts/DefaultLayout";
 
-const CoordinatorPage = (): JSX.Element => <Layout requireAuth>This is the coordinator page.</Layout>;
+const CoordinatorPage = (): JSX.Element => (
+  <Layout requireAuth>
+    <div>
+      <p>This is the coordinator page.</p>
+
+      <p>You are using version with commit: {config.commitHash}</p>
+    </div>
+  </Layout>
+);
 
 export default CoordinatorPage;


### PR DESCRIPTION
**Description**
- [x] Read commit version before `start`, `dev`, and `build`, and write to the `.env` file.
- [x] display on the organizer board & footer

**Related Issues**
close #551 


**Discussion**
1. Is there any easier way to accomplish this? 
2. should the commit be displayed to everyone during the `development` mode? or only the organizer?
3. where to put it?