### PR TITLE
fix: tally result id collision

### DIFF
--- a/packages/interface/src/server/api/routers/results.ts
+++ b/packages/interface/src/server/api/routers/results.ts
@@ -58,8 +58,11 @@ export async function calculateMaciResults(
     });
   }
 
-  const results = tallyData.results.reduce((acc, tally, index) => {
-    const project = projects[index];
+  const results = tallyData.results.reduce((acc, tally) => {
+    /// The tallyResult.id on old version subgraph is 0, 1, 2, ..., and is {tallyAddress}-{id=0, 1, 2, ...} on new version
+    const [id1, id2] = tally.id.split("-");
+    const projectIndex = id2 ? Number(id2) : Number(id1);
+    const project = projects[projectIndex];
     if (project) {
       acc.set(project.id, { votes: Number(tally.result), voters: 0 });
     }

--- a/packages/subgraph/README.md
+++ b/packages/subgraph/README.md
@@ -15,5 +15,5 @@
 ```
 
 3. Run `pnpm run build`. You can use env variables `NETWORK` and `VERSION` to switch config files.
-4. Run `graph auth --studio {key}`. You can find the key in subgraph studio dashboard.
-5. Run `pnpm run deploy` to deploy subgraph
+4. Run `graph auth --studio {key}`. You can find the key in subgraph studio dashboard; if you're using alchemy graph, skip this step.
+5. Run `pnpm run deploy` to deploy subgraph; if you're using alchemy graph, run `pnpm run deploy-alchemy --deploy-key {key}` instead.

--- a/packages/subgraph/package.json
+++ b/packages/subgraph/package.json
@@ -19,6 +19,7 @@
     "prebuild": "pnpm codegen",
     "build": "graph build",
     "deploy": "graph deploy --node https://api.studio.thegraph.com/deploy/ maci-subgraph",
+    "deploy-alchemy": "graph deploy maci-subgraph --node https://subgraphs.alchemy.com/api/subgraphs/deploy/ --ipfs https://ipfs.satsuma.xyz",
     "create-local": "graph create --node http://localhost:8020/ maci-subgraph",
     "remove-local": "graph remove --node http://localhost:8020/ maci-subgraph",
     "deploy-local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 maci-subgraph --network localhost",

--- a/packages/subgraph/src/utils/entity.ts
+++ b/packages/subgraph/src/utils/entity.ts
@@ -151,10 +151,12 @@ export const createOrLoadClaim = (index: GraphBN, recipient: Bytes, amount: Grap
 };
 
 export const createOrLoadTallyResult = (index: GraphBN, result: GraphBN, tally: Bytes): TallyResult => {
-  let tallyResult = TallyResult.load(index.toString());
+  // Create composite key by combining tally address and index
+  const compositeId = `${tally.toHexString()}-${index.toString()}`;
+  let tallyResult = TallyResult.load(compositeId);
 
   if (!tallyResult) {
-    tallyResult = new TallyResult(index.toString());
+    tallyResult = new TallyResult(compositeId);
     tallyResult.result = result;
     tallyResult.tally = tally;
     tallyResult.save();

--- a/packages/subgraph/tests/tally/tally.test.ts
+++ b/packages/subgraph/tests/tally/tally.test.ts
@@ -45,7 +45,7 @@ describe("Tally", () => {
 
     handleAddResult(event);
 
-    const tallyResult = TallyResult.load(event.params.index.toString())!;
+    const tallyResult = TallyResult.load(`${DEFAULT_TALLY_ADDRESS.toHexString()}-${event.params.index.toString()}`)!;
 
     assert.fieldEquals("TallyResult", tallyResult.id, "result", event.params.result.toString());
   });


### PR DESCRIPTION
# Description
This is to solve the tallyResult id collision on the subgraph, meanwhile make sure the interface works well after this change.

Because of the rebase issue, this is same PR as #584  & #583 , but branch from the latest `main` branch.

## Additional Notes

I found that the interface mapping result with tally result never uses the result id, that's why we didn't find this problem before. We need to have 100% confidence that the subgraph returns tally result 1 by 1 following the index of the projects.
(So actually, maybe it's better that we use the `result.id` instead of the `index` of the loop?)

see here:
https://github.com/privacy-scaling-explorations/maci-platform/blob/c0e35afe42083c6580f64b2ae4c2ce6658458a29/packages/interface/src/server/api/routers/results.ts#L61-L68

## Related issue(s)

<!-- Please list here with closing keywords any issues that this pull request is related to (fix #$ISSUE_NUMBER). -->

## Confirmation

> [!IMPORTANT]
> We do not accept minor grammatical fixes (e.g., correcting typos, rewording sentences) unless they significantly improve clarity in technical documentation. These contributions, while appreciated, are not a priority for merging. If there is a grammatical error feel free to message the team.

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I run and verified that all tests pass acording to MACI's [testing guide](https://maci.pse.dev/docs/guides/testing).
