### PR TITLE
fix(frontend): preserve dark/light mode state when navigating from ro…

### DIFF
--- a/packages/interface/src/features/results/components/ResultItem.tsx
+++ b/packages/interface/src/features/results/components/ResultItem.tsx
@@ -26,7 +26,7 @@ export const ResultItem = ({ pollId, rank, project }: IResultItemProps): JSX.Ele
 
   return (
     <Link href={`/rounds/${pollId}/${project.id}`}>
-      <div className="flex cursor-pointer leading-8 hover:bg-blue-50">
+      <div className="flex cursor-pointer leading-8 hover:bg-blue-50 dark:hover:bg-blue-50/10">
         <div className="my-1 w-8 flex-none justify-center">
           {rank === 1 && <Image alt="gold" height="26" src="/gold.svg" width="26" />}
 
@@ -35,11 +35,11 @@ export const ResultItem = ({ pollId, rank, project }: IResultItemProps): JSX.Ele
           {rank === 3 && <Image alt="bronze" height="26" src="/bronze.svg" width="26" />}
         </div>
 
-        <div className="w-6 flex-none text-center">{rank}</div>
+        <div className="w-6 flex-none text-center dark:text-white">{rank}</div>
 
-        <div className="mx-2 flex-1">{metadata.data?.name}</div>
+        <div className="mx-2 flex-1 dark:text-white">{metadata.data?.name}</div>
 
-        <div className="w-24 flex-none text-end">{`${project.votes} votes`}</div>
+        <div className="w-24 flex-none text-end dark:text-white">{`${project.votes} votes`}</div>
       </div>
     </Link>
   );


### PR DESCRIPTION
# Description

Fix issue #511: Resolve the dark mode rendering issue on specific pages.
- The only identified problem is with the `Leaderboard`. Please inform me if there are any other occurrences, as this is the only one I was able to reproduce.

#### Before  
<img width="2028" alt="Screenshot 2025-01-23 at 20 52 05" src="https://github.com/user-attachments/assets/b9f523d1-38e2-46bd-8cba-8962b077d8bc" />

#### After 
<img width="1908" alt="Screenshot 2025-01-23 at 20 52 48" src="https://github.com/user-attachments/assets/c5920e76-dc2a-4b8b-bb15-d50fc3d4b52a" />

## Related issue(s)

<!-- Please list here with closing keywords any issues that this pull request is related to (fix #$ISSUE_NUMBER). -->

## Confirmation

> [!IMPORTANT]
> We do not accept minor grammatical fixes (e.g., correcting typos, rewording sentences) unless they significantly improve clarity in technical documentation. These contributions, while appreciated, are not a priority for merging. If there is a grammatical error feel free to message the team.

- [x] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [x] I run and verified that all tests pass acording to MACI's [testing guide](https://maci.pse.dev/docs/guides/testing).
