### PR TITLE
fix: resolve project listing issue

### DIFF
--- a/packages/interface/src/features/applications/components/ApplicationItem.tsx
+++ b/packages/interface/src/features/applications/components/ApplicationItem.tsx
@@ -56,7 +56,9 @@ export const ApplicationItem = ({
         </label>
 
         <div className="flex flex-[5] items-center gap-4 sm:flex-[8]">
-          <ProjectAvatar isLoading={isLoading} size="sm" url={profileImageUrl} />
+          <div className="flex items-center justify-center">
+            <ProjectAvatar isLoading={isLoading} size="sm" url={profileImageUrl} />
+          </div>
 
           <div className="flex flex-col">
             <Skeleton className="mb-1 min-h-5 min-w-24" isLoading={isLoading}>


### PR DESCRIPTION
# Description

The project listing image becomes stretched when the project description contains too much text. This PR ensures that the image block maintains its proper spacing.

## Additional Notes

#### Issue
<img width="1453" alt="Screenshot 2025-01-27 at 16 46 37" src="https://github.com/user-attachments/assets/e1c817c3-f641-4f23-a7f1-db154c62b402" />


#### Fix
<img width="1551" alt="Screenshot 2025-01-27 at 17 36 14" src="https://github.com/user-attachments/assets/f393aa3e-3fba-4105-9ea7-1a7b4fea4541" />

<!-- If there are any additional notes, requirements or special instructions related to this PR, please specify them here. -->

## Related issue(s)

<!-- Please list here with closing keywords any issues that this pull request is related to (fix #$ISSUE_NUMBER). -->

## Confirmation

> [!IMPORTANT]
> We do not accept minor grammatical fixes (e.g., correcting typos, rewording sentences) unless they significantly improve clarity in technical documentation. These contributions, while appreciated, are not a priority for merging. If there is a grammatical error feel free to message the team.

- [ ] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [ ] I run and verified that all tests pass acording to MACI's [testing guide](https://maci.pse.dev/docs/guides/testing).
