### PR TITLE
feat: randomize display of projects by adding a random seed in locale storage

### DIFF
--- a/packages/interface/src/features/rounds/components/Projects.tsx
+++ b/packages/interface/src/features/rounds/components/Projects.tsx
@@ -15,9 +15,10 @@ import { useMaci } from "~/contexts/Maci";
 import { useRound } from "~/contexts/Round";
 import { useIsMobile } from "~/hooks/useIsMobile";
 import { useMyProjects } from "~/hooks/useProjects";
+import { useRandomizedProjects } from "~/hooks/useRandomizedProjects";
 import { useResults } from "~/hooks/useResults";
 import { useRoundState } from "~/utils/state";
-import { ERoundState } from "~/utils/types";
+import { ERoundState, IRecipient } from "~/utils/types";
 
 import { ProjectItem, ProjectItemAwarded } from "../../projects/components/ProjectItem";
 import { useSearchProjects } from "../../projects/hooks/useProjects";
@@ -43,6 +44,8 @@ export const Projects = ({ pollId = "" }: IProjectsProps): JSX.Element => {
     search: deferredSearchTerm,
     registryAddress: round?.registryAddress ?? zeroAddress,
   });
+
+  const randomizedProjects = useRandomizedProjects(projects, pollId);
 
   const { isRegistered } = useMaci();
   const { addToBallot, removeFromBallot, ballotContains, getBallot } = useBallot();
@@ -172,8 +175,8 @@ export const Projects = ({ pollId = "" }: IProjectsProps): JSX.Element => {
       )}
 
       <InfiniteLoading
-        {...projects}
-        renderItem={(item, { isLoading }) => (
+        {...randomizedProjects}
+        renderItem={(item: IRecipient, { isLoading }) => (
           <div key={item.id} className={clsx("relative", { "animate-pulse": isLoading })}>
             {!results.isLoading && roundState === ERoundState.RESULTS ? (
               <ProjectItemAwarded amount={results.data?.projects[item.id]?.votes} />

--- a/packages/interface/src/hooks/useRandomizedProjects.ts
+++ b/packages/interface/src/hooks/useRandomizedProjects.ts
@@ -1,0 +1,44 @@
+import { type InfiniteData } from "@tanstack/react-query";
+import { type UseTRPCInfiniteQueryResult } from "@trpc/react-query/shared";
+import { useMemo, useState } from "react";
+
+import { IRecipient } from "~/utils/types";
+
+type RandomizedProjectsResult = UseTRPCInfiniteQueryResult<IRecipient[], unknown, unknown>;
+
+export function useRandomizedProjects(projects: RandomizedProjectsResult, pollId: string): RandomizedProjectsResult {
+  const [randomSeed] = useState(() => {
+    try {
+      if (typeof window === "undefined") {
+        return Math.random();
+      }
+
+      const storedSeed = window.localStorage.getItem(`projectRandomSeed-${pollId}`);
+      if (storedSeed) {
+        return parseFloat(storedSeed);
+      }
+      const newSeed = Math.random();
+      window.localStorage.setItem(`projectRandomSeed-${pollId}`, newSeed.toString());
+      return newSeed;
+    } catch {
+      return Math.random();
+    }
+  });
+
+  // @ts-expect-error - this is a temporary fix to allow the randomized projects to be used in the projects component
+  return useMemo(() => {
+    if (!projects.data) {
+      return projects as RandomizedProjectsResult;
+    }
+
+    const data = projects.data as InfiniteData<IRecipient[]>;
+
+    return {
+      ...projects,
+      data: {
+        ...data,
+        pages: data.pages.map((page) => [...page].sort(() => randomSeed - 0.5)),
+      },
+    };
+  }, [projects, randomSeed]);
+}


### PR DESCRIPTION
# Description
This PR fixes #553 

Randomize the display of projects by generating a random seed stored in local storage. 
The seed ensures that the project list appears in the same randomized order every time the user returns to the dashboard.

## Additional Notes

<!-- If there are any additional notes, requirements or special instructions related to this PR, please specify them here. -->

## Related issue(s)

<!-- Please list here with closing keywords any issues that this pull request is related to (fix #$ISSUE_NUMBER). -->

## Confirmation

> [!IMPORTANT]
> We do not accept minor grammatical fixes (e.g., correcting typos, rewording sentences) unless they significantly improve clarity in technical documentation. These contributions, while appreciated, are not a priority for merging. If there is a grammatical error feel free to message the team.

- [ ] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [ ] I run and verified that all tests pass acording to MACI's [testing guide](https://maci.pse.dev/docs/guides/testing).
