### PR TITLE
fix: dark/light mode mode not set to default

### DIFF
--- a/packages/interface/src/components/Header.tsx
+++ b/packages/interface/src/components/Header.tsx
@@ -4,7 +4,7 @@ import dynamic from "next/dynamic";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { useTheme } from "next-themes";
-import { type ComponentPropsWithRef, useState, useCallback, useMemo } from "react";
+import { type ComponentPropsWithRef, useState, useCallback, useMemo, useEffect } from "react";
 
 import { useBallot } from "~/contexts/Ballot";
 import { useRoundState } from "~/utils/state";
@@ -67,6 +67,14 @@ const Header = ({ navLinks, pollId = "" }: IHeaderProps) => {
   const { theme, setTheme } = useTheme();
 
   const ballot = useMemo(() => getBallot(pollId), [pollId, getBallot]);
+
+  // set default theme to light if it's not set
+  useEffect(() => {
+    const defaultTheme = theme === "dark" ? "dark" : "light";
+    if (!["dark", "light"].includes(theme ?? "")) {
+      setTheme(defaultTheme);
+    }
+  }, []);
 
   const handleChangeTheme = useCallback(() => {
     setTheme(theme === "light" ? "dark" : "light");


### PR DESCRIPTION
# Description

<!-- Please provide a detailed description of the pull request you are opening. -->

This PR fixes #511

- [x] Fix the issue where the default theme is not set to the default value
- [x] Ensure that the theme changes correctly on the first click when toggling the color mode

## Additional Notes

<!-- If there are any additional notes, requirements or special instructions related to this PR, please specify them here. -->

## Related issue(s)

<!-- Please list here with closing keywords any issues that this pull request is related to (fix #$ISSUE_NUMBER). -->

## Confirmation

> [!IMPORTANT]
> We do not accept minor grammatical fixes (e.g., correcting typos, rewording sentences) unless they significantly improve clarity in technical documentation. These contributions, while appreciated, are not a priority for merging. If there is a grammatical error feel free to message the team.

- [ ] I have read and understand MACI's [contributor guidelines](https://maci.pse.dev/docs/contributing) and [code of conduct](https://maci.pse.dev/docs/contributing/code-of-conduct).
- [ ] I run and verified that all tests pass acording to MACI's [testing guide](https://maci.pse.dev/docs/guides/testing).
